### PR TITLE
No longer warning when formatted value is longer than the `xx.x` format

### DIFF
--- a/R/apply_statistic_fmt_fn.R
+++ b/R/apply_statistic_fmt_fn.R
@@ -54,11 +54,11 @@ apply_statistic_fmt_fn <- function(x) {
 
     fn <- function(y) {
       fmt <- format(round5(y * scale, digits = decimal_n), nsmall = decimal_n)
-      if (nchar(fmt) > width) {
-        cli::cli_warn("Formatted statistic, {.val {fmt}}, is longer than allowed by format {.val {x}}", call = call)
-        return(fmt)
-      }
-      paste0(strrep(" ", width - nchar(fmt)), fmt)
+      ifelse(
+        nchar(fmt) >= width,
+        fmt,
+        paste0(strrep(" ", width - nchar(fmt)), fmt)
+      )
     }
 
     return(fn)

--- a/tests/testthat/_snaps/apply_statistic_fmt_fn.md
+++ b/tests/testthat/_snaps/apply_statistic_fmt_fn.md
@@ -33,14 +33,6 @@
     Code
       apply_statistic_fmt_fn(dplyr::mutate(ard_fmt_checks, statistic = lapply(
         statistic, function(x) x * 1000), statistic_fmt_fn = list("xx", "xx")))
-    Condition
-      Warning:
-      There were 2 warnings in `dplyr::mutate()`.
-      The first warning was:
-      i In argument: `statistic_fmt = map2(...)`.
-      Caused by warning:
-      ! Formatted statistic, "20091", is longer than allowed by format "xx"
-      i Run `dplyr::last_dplyr_warnings()` to see the 1 remaining warning.
     Output
       # A tibble: 2 x 9
         variable context stat_name stat_label statistic statistic_fmt statistic_fmt_fn

--- a/tests/testthat/_snaps/ard_continuous.md
+++ b/tests/testthat/_snaps/ard_continuous.md
@@ -1,3 +1,10 @@
+# ard_continuous() works
+
+    Code
+      class(ard_test)
+    Output
+      [1] "card"       "tbl_df"     "tbl"        "data.frame"
+
 # ard_continuous(fmt_fn) argument works
 
     Code

--- a/tests/testthat/test-apply_statistic_fmt_fn.R
+++ b/tests/testthat/test-apply_statistic_fmt_fn.R
@@ -96,6 +96,7 @@ test_that("apply_statistic_fmt_fn() error messaging", {
     error = TRUE
   )
 
+  # everything still works when the formatted value is longer than the xxx string
   expect_snapshot(
     ard_fmt_checks |>
       dplyr::mutate(


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Previously, if the formatting instructions were "xx" and the rounded value was "100", a warning was printed indicating that "100" is longer than the format instruction. This warning no longer appears.

--------------------------------------------------------------------------------

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] Ensure all package dependencies are installed: `devtools::install_dev_deps()`
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Increment the version number using `usethis::use_version(which = "dev")`
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".
