### PR TITLE
`compute_formula_selector()` now removed named elements not present in `data` argument

### DIFF
--- a/R/ard_continuous.R
+++ b/R/ard_continuous.R
@@ -166,9 +166,7 @@ ard_continuous <- function(data,
   df_results |>
     dplyr::mutate(context = "continuous") |>
     tidy_ard_column_order() %>%
-    {
-      structure(., class = c("card", class(.)))
-    }
+    {structure(., class = c("card", class(.)))} # styler: off
 }
 
 
@@ -309,21 +307,19 @@ ard_continuous <- function(data,
             x[c("variable", "stat_name")] |>
             dplyr::filter(.data$variable %in% .env$variable) |>
             unique() %>%
-            {
-              stats::setNames(as.list(.[["stat_name"]]), .[["stat_name"]])
-            }
+            {stats::setNames(as.list(.[["stat_name"]]), .[["stat_name"]])} # styler: off
 
           compute_formula_selector(
             data = lst_stat_names,
             x = enlst_arg
           ) %>%
-            {
-              dplyr::tibble(
+            # styler: off
+            {dplyr::tibble(
                 variable = variable,
                 stat_name = names(.),
                 "{new_column}" := unname(.)
-              )
-            }
+            )}
+          # styler: on
         }
       ) |>
       dplyr::bind_rows()

--- a/R/process_selectors.R
+++ b/R/process_selectors.R
@@ -166,7 +166,7 @@ fill_formula_selectors <- function(data, ..., env = caller_env()) {
 compute_formula_selector <- function(data, x, arg_name = caller_arg(x), env = caller_env(), strict = TRUE) {
   # user passed a named list, return unaltered
   if (.is_named_list(x)) {
-    return(x)
+    return(x[intersect(names(x), names(data))])
   }
 
   # if user passed a single formula, wrap it in a list
@@ -214,11 +214,10 @@ compute_formula_selector <- function(data, x, arg_name = caller_arg(x), env = ca
   # flatten the list to a top-level list only
   x <- .purrr_list_flatten(x)
 
-  # remove duplicates (keeping the last one)
-  x[names(x) |>
-    rev() |>
-    Negate(duplicated)() |>
-    rev()]
+  # remove duplicates (keeping the last one), and only keeping names in the data frame
+  x <- x[names(x) |> rev() |> Negate(duplicated)() |> rev()] # styler: off
+
+  x[intersect(names(x), names(data))]
 }
 
 #' @name process_selectors

--- a/tests/testthat/test-process_selectors.R
+++ b/tests/testthat/test-process_selectors.R
@@ -35,13 +35,13 @@ test_that("process_formula_selectors() works", {
   )
 
   # works with more than on argument
-  expect_equal(
-    {
-      process_formula_selectors(mtcars, variables = starts_with("a") ~ 1L, by = list(am = 1L))
-      list(variables = variables, by = by)
-    },
+  # styler: off
+  expect_equal({
+    process_formula_selectors(mtcars, variables = starts_with("a") ~ 1L, by = list(am = 1L))
+    list(variables = variables, by = by)},
     list(variables = list(am = 1L), by = list(am = 1L))
   )
+  # styler: on
 })
 
 test_that("process_formula_selectors() error messaging", {
@@ -57,5 +57,29 @@ test_that("compute_formula_selector() selects the last assignment when multiple 
       data = mtcars[c("mpg", "hp")],
       x = list(everything() ~ "THE DEFAULT", mpg = "Special for MPG")
     )
+  )
+
+
+  # named list elements that are not in `data` are removed from returned result
+  expect_equal(
+    compute_formula_selector(
+      data = mtcars[c("mpg", "hp")],
+      x = list(everything() ~ "THE DEFAULT", not_present = "Special for MPG")
+    ),
+    list(mpg = "THE DEFAULT", hp = "THE DEFAULT")
+  )
+  expect_equal(
+    compute_formula_selector(
+      data = mtcars[c("mpg", "hp")],
+      x = list(mpg = "THE DEFAULT", not_present = "Special for MPG")
+    ),
+    list(mpg = "THE DEFAULT")
+  )
+  expect_equal(
+    compute_formula_selector(
+      data = mtcars[c("mpg", "hp")],
+      x = list(not_present = "Special for MPG")
+    ),
+    list(NAME = NULL) |> compact()
   )
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* `compute_formula_selector()` now removed named elements not present in `data` argument. This update also applies to `process_formula_selectors()`. 

``` r
cards::compute_formula_selector(
  data = mtcars[c("mpg", "hp")],
  x = list(hp = "Present in data", not_present = "Not present in data")
)
#> $hp
#> [1] "Present in data"
```

<sup>Created on 2024-02-02 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

@bzkrouse FYI, I am going to merge, so I can keep working on something. If you want to discuss this change, let me know!

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
