### PR TITLE
Adding env to processed formulas

### DIFF
--- a/R/process_selectors.R
+++ b/R/process_selectors.R
@@ -202,7 +202,8 @@ compute_formula_selector <- function(data, x, arg_name = caller_arg(x), env = ca
       x[i] <-
         rep_len(
           list(
-            eval_tidy(f_rhs(x[[i]]), env = attr(x[[i]], ".Environment"))
+            eval_tidy(f_rhs(x[[i]]), env = attr(x[[i]], ".Environment")) |>
+              structure(.Environment = attr(x[[i]], ".Environment"))
           ),
           length.out = length(colnames)
         ) |>
@@ -214,9 +215,10 @@ compute_formula_selector <- function(data, x, arg_name = caller_arg(x), env = ca
   # flatten the list to a top-level list only
   x <- .purrr_list_flatten(x)
 
-  # remove duplicates (keeping the last one), and only keeping names in the data frame
+  # remove duplicates (keeping the last one)
   x <- x[names(x) |> rev() |> Negate(duplicated)() |> rev()] # styler: off
 
+  # only keeping names in the data frame
   x[intersect(names(x), names(data))]
 }
 

--- a/man/process_selectors.Rd
+++ b/man/process_selectors.Rd
@@ -10,7 +10,7 @@
 \usage{
 process_selectors(data, ..., env = caller_env())
 
-process_formula_selectors(data, ..., env = caller_env())
+process_formula_selectors(data, ..., env = caller_env(), include_env = FALSE)
 
 fill_formula_selectors(data, ..., env = caller_env())
 
@@ -19,7 +19,8 @@ compute_formula_selector(
   x,
   arg_name = caller_arg(x),
   env = caller_env(),
-  strict = TRUE
+  strict = TRUE,
+  include_env = FALSE
 )
 
 check_list_elements(
@@ -50,6 +51,10 @@ a function.
 \item{env}{(\code{environment})\cr
 env to save the results to. Default is the calling environment.}
 
+\item{include_env}{(\code{logical} scalar)\cr
+whether to include the environment from the formula object in the returned
+named list. Default is \code{FALSE}}
+
 \item{x}{\itemize{
 \item \code{compute_formula_selector()}: (\code{\link[=syntax]{formula-list-selector}})\cr
 a named list, list of formulas, or a single formula that will be
@@ -64,7 +69,7 @@ in error messaging. Default is \code{caller_arg(x)}}
 
 \item{strict}{(\code{logical} scalar)\cr
 whether to throw an error if a variable doesn't exist in the reference data
-(passed to \code{tidyselect::eval_select})}
+(passed to \code{tidyselect::eval_select()})}
 
 \item{predicate}{a predicate function that returns \code{TRUE} or \code{FALSE}}
 

--- a/tests/testthat/_snaps/process_selectors.md
+++ b/tests/testthat/_snaps/process_selectors.md
@@ -19,8 +19,7 @@
 # compute_formula_selector() selects the last assignment when multiple appear
 
     Code
-      compute_formula_selector(data = mtcars[c("mpg", "hp")], x = list(everything() ~
-        "THE DEFAULT", mpg = "Special for MPG"))
+      lapply(lst_compute_test, function(x) structure(x, .Environment = NULL))
     Output
       $hp
       [1] "THE DEFAULT"

--- a/tests/testthat/test-process_selectors.R
+++ b/tests/testthat/test-process_selectors.R
@@ -33,7 +33,7 @@ test_that("process_formula_selectors() works", {
     list(variables = list(am = 1L)),
     ignore_attr = TRUE
   )
-  # styler: off
+  # styler: on
 
   # works with more than on argument
   # styler: off
@@ -57,10 +57,10 @@ test_that("compute_formula_selector() selects the last assignment when multiple 
   formula_selcect_test <- everything() ~ "THE DEFAULT"
   expect_error(
     lst_compute_test <-
-    compute_formula_selector(
-      data = mtcars[c("mpg", "hp")],
-      x = list(formula_selcect_test, mpg = "Special for MPG")
-    ),
+      compute_formula_selector(
+        data = mtcars[c("mpg", "hp")],
+        x = list(formula_selcect_test, mpg = "Special for MPG")
+      ),
     NA
   )
 

--- a/tests/testthat/test-process_selectors.R
+++ b/tests/testthat/test-process_selectors.R
@@ -28,7 +28,7 @@ test_that("process_formula_selectors() works", {
   # works with a single argument
   # styler: off
   expect_equal({
-    process_formula_selectors(mtcars, variables = starts_with("a") ~ 1L)
+    process_formula_selectors(mtcars, variables = starts_with("a") ~ 1L, include_env = TRUE)
     list(variables = variables)},
     list(variables = list(am = 1L)),
     ignore_attr = TRUE
@@ -38,7 +38,9 @@ test_that("process_formula_selectors() works", {
   # works with more than on argument
   # styler: off
   expect_equal({
-    process_formula_selectors(mtcars, variables = starts_with("a") ~ 1L, by = list(am = 1L))
+    process_formula_selectors(
+      mtcars, variables = starts_with("a") ~ 1L, by = list(am = 1L), include_env = TRUE
+    )
     list(variables = variables, by = by)},
     list(variables = list(am = 1L), by = list(am = 1L)),
     ignore_attr = TRUE
@@ -59,7 +61,8 @@ test_that("compute_formula_selector() selects the last assignment when multiple 
     lst_compute_test <-
       compute_formula_selector(
         data = mtcars[c("mpg", "hp")],
-        x = list(formula_selcect_test, mpg = "Special for MPG")
+        x = list(formula_selcect_test, mpg = "Special for MPG"),
+        include_env = TRUE
       ),
     NA
   )

--- a/tests/testthat/test-process_selectors.R
+++ b/tests/testthat/test-process_selectors.R
@@ -26,20 +26,22 @@ test_that("process_selectors() works", {
 
 test_that("process_formula_selectors() works", {
   # works with a single argument
-  expect_equal(
-    {
-      process_formula_selectors(mtcars, variables = starts_with("a") ~ 1L)
-      list(variables = variables)
-    },
-    list(variables = list(am = 1L))
+  # styler: off
+  expect_equal({
+    process_formula_selectors(mtcars, variables = starts_with("a") ~ 1L)
+    list(variables = variables)},
+    list(variables = list(am = 1L)),
+    ignore_attr = TRUE
   )
+  # styler: off
 
   # works with more than on argument
   # styler: off
   expect_equal({
     process_formula_selectors(mtcars, variables = starts_with("a") ~ 1L, by = list(am = 1L))
     list(variables = variables, by = by)},
-    list(variables = list(am = 1L), by = list(am = 1L))
+    list(variables = list(am = 1L), by = list(am = 1L)),
+    ignore_attr = TRUE
   )
   # styler: on
 })
@@ -52,11 +54,29 @@ test_that("process_formula_selectors() error messaging", {
 })
 
 test_that("compute_formula_selector() selects the last assignment when multiple appear", {
-  expect_snapshot(
+  formula_selcect_test <- everything() ~ "THE DEFAULT"
+  expect_error(
+    lst_compute_test <-
     compute_formula_selector(
       data = mtcars[c("mpg", "hp")],
-      x = list(everything() ~ "THE DEFAULT", mpg = "Special for MPG")
-    )
+      x = list(formula_selcect_test, mpg = "Special for MPG")
+    ),
+    NA
+  )
+
+  # test the formula env is the same as the attached attr env
+  expect_equal(
+    formula_selcect_test |>
+      attr(".Environment"),
+    lst_compute_test[["hp"]] |>
+      attr(".Environment")
+  )
+
+  # remove the env from the snapshot as it changes with each run.
+  # just testing the values
+  expect_snapshot(
+    lst_compute_test |>
+      lapply(\(x) structure(x, .Environment = NULL))
   )
 
 
@@ -66,7 +86,8 @@ test_that("compute_formula_selector() selects the last assignment when multiple 
       data = mtcars[c("mpg", "hp")],
       x = list(everything() ~ "THE DEFAULT", not_present = "Special for MPG")
     ),
-    list(mpg = "THE DEFAULT", hp = "THE DEFAULT")
+    list(mpg = "THE DEFAULT", hp = "THE DEFAULT"),
+    ignore_attr = TRUE
   )
   expect_equal(
     compute_formula_selector(


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* This update adds as an attribute the environment associated with a pre-processed formula selector in `compute_formula_selector()` (and as a result, `process_formula_selectors()` as well). It's not uncommon that users will create the formulas in unexpected environments (which are saved with the formula), and we need access to this env during evaluation.

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #157

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
