### PR TITLE
`ard_categorical(denominator)` updates for missing variables

### DIFF
--- a/man/dot-table_as_df.Rd
+++ b/man/dot-table_as_df.Rd
@@ -9,6 +9,7 @@
   variable = NULL,
   by = NULL,
   strata = NULL,
+  useNA = c("no", "always"),
   count_column = "...ard_n..."
 )
 }

--- a/tests/testthat/test-ard_categorical.R
+++ b/tests/testthat/test-ard_categorical.R
@@ -283,6 +283,33 @@ test_that("ard_categorical(denominator='cell') works", {
       getElement(1),
     mtrx_percs["<65", "Placebo"]
   )
+
+  # works with an all missing variable
+  df_missing <- dplyr::tibble(all_na_lgl = c(NA, NA), letters = letters[1:2])
+  expect_equal(
+    ard_categorical(
+      data = df_missing,
+      variable  = all_na_lgl,
+      statistics = ~categorical_variable_summary_fns(c("n", "N")),
+      denominator = "cell"
+    ) |>
+      dplyr::pull(statistic) |>
+      unlist(),
+    rep_len(0L, length.out = 4L)
+  )
+
+  expect_equal(
+    ard_categorical(
+      data = df_missing,
+      variable  = all_na_lgl,
+      by = letters,
+      statistics = ~categorical_variable_summary_fns(c("n", "N")),
+      denominator = "cell"
+    ) |>
+      dplyr::pull(statistic) |>
+      unlist(),
+    rep_len(0L, length.out = 8L)
+  )
 })
 
 test_that("ard_categorical(denominator='row') works", {
@@ -347,6 +374,33 @@ test_that("ard_categorical(denominator='row') works", {
       dplyr::select(-statistic_fmt_fn, -warning, -error) |>
       as.data.frame()
   )
+
+  # works with an all missing variable
+  df_missing <- dplyr::tibble(all_na_lgl = c(NA, NA), letters = letters[1:2])
+  expect_equal(
+    ard_categorical(
+      data = df_missing,
+      variable  = all_na_lgl,
+      statistics = ~categorical_variable_summary_fns(c("n", "N")),
+      denominator = "row"
+    ) |>
+      dplyr::pull(statistic) |>
+      unlist(),
+    rep_len(0L, length.out = 4L)
+  )
+
+  expect_equal(
+    ard_categorical(
+      data = df_missing,
+      variable  = all_na_lgl,
+      by = letters,
+      statistics = ~categorical_variable_summary_fns(c("n", "N")),
+      denominator = "row"
+    ) |>
+      dplyr::pull(statistic) |>
+      unlist(),
+    rep_len(0L, length.out = 8L)
+  )
 })
 
 test_that("ard_categorical(denominator='column') works", {
@@ -355,6 +409,60 @@ test_that("ard_categorical(denominator='column') works", {
       dplyr::select(all_ard_groups(), all_ard_variables(), stat_name, statistic),
     ard_categorical(ADSL, variables = "AGEGR1", by = "ARM") |>
       dplyr::select(all_ard_groups(), all_ard_variables(), stat_name, statistic)
+  )
+
+  # works with an all missing variable
+  df_missing <- dplyr::tibble(all_na_lgl = c(NA, NA), letters = letters[1:2])
+  expect_equal(
+    ard_categorical(
+      data = df_missing,
+      variable  = all_na_lgl,
+      statistics = ~categorical_variable_summary_fns(c("n", "N")),
+      denominator = "column"
+    ) |>
+      dplyr::pull(statistic) |>
+      unlist(),
+    rep_len(0L, length.out = 4L)
+  )
+
+  expect_equal(
+    ard_categorical(
+      data = df_missing,
+      variable  = all_na_lgl,
+      by = letters,
+      statistics = ~categorical_variable_summary_fns(c("n", "N")),
+      denominator = "column"
+    ) |>
+      dplyr::pull(statistic) |>
+      unlist(),
+    rep_len(0L, length.out = 8L)
+  )
+
+  # works with an all missing variable
+  df_missing <- dplyr::tibble(all_na_lgl = c(NA, NA), letters = letters[1:2])
+  expect_equal(
+    ard_categorical(
+      data = df_missing,
+      variable  = all_na_lgl,
+      statistics = ~categorical_variable_summary_fns(c("n", "N")),
+      denominator = "column"
+    ) |>
+      dplyr::pull(statistic) |>
+      unlist(),
+    rep_len(0L, length.out = 4L)
+  )
+
+  expect_equal(
+    ard_categorical(
+      data = df_missing,
+      variable  = all_na_lgl,
+      by = letters,
+      statistics = ~categorical_variable_summary_fns(c("n", "N")),
+      denominator = "column"
+    ) |>
+      dplyr::pull(statistic) |>
+      unlist(),
+    rep_len(0L, length.out = 8L)
   )
 })
 
@@ -409,6 +517,38 @@ test_that("ard_categorical(denominator=<data frame with counts>) works", {
       variables = AGEGR1
     ) |>
       dplyr::select(-statistic_fmt_fn)
+  )
+})
+
+test_that("ard_categorical(denominator=<data frame without counts>) works", {
+  expect_equal(
+    ADSL |>
+      dplyr::mutate(AGEGR1 = NA) |>
+      ard_categorical(
+        variables = AGEGR1,
+        statistics = ~categorical_variable_summary_fns(c("n", "p")),
+        denominator = rep_len(list(ADSL), 10L) |> dplyr::bind_rows()
+      ) |>
+      dplyr::pull(statistic) |>
+      unlist() |>
+      unique(),
+    0L
+  )
+
+
+  expect_equal(
+    ADSL |>
+      dplyr::mutate(AGEGR1 = NA) |>
+      ard_categorical(
+        variables = AGEGR1,
+        by = ARM,
+        statistics = ~categorical_variable_summary_fns(c("n", "p")),
+        denominator = rep_len(list(ADSL), 10L) |> dplyr::bind_rows()
+      ) |>
+      dplyr::pull(statistic) |>
+      unlist() |>
+      unique(),
+    0L
   )
 })
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* When there were by strata present in `ard_categorical()` would error when the variable was all NA, and now that scenario can be tabulated.


--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
