### PR TITLE
add default to `tidy_as_ard()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cards
 Title: Analysis Results Data
-Version: 0.0.0.9031
+Version: 0.0.0.9032
 Authors@R: c(
     person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0862-2018")),

--- a/R/tidy_as_ard.R
+++ b/R/tidy_as_ard.R
@@ -56,7 +56,7 @@
 #' my_ard_fishertest(mtcars, by = "am", variable = "vs")
 tidy_as_ard <- function(lst_tidy,
                         tidy_result_names,
-                        fun_args_to_record,
+                        fun_args_to_record = character(0L),
                         formals = list(),
                         passed_args = list(),
                         lst_ard_columns) {

--- a/man/tidy_as_ard.Rd
+++ b/man/tidy_as_ard.Rd
@@ -7,7 +7,7 @@
 tidy_as_ard(
   lst_tidy,
   tidy_result_names,
-  fun_args_to_record,
+  fun_args_to_record = character(0L),
   formals = list(),
   passed_args = list(),
   lst_ard_columns

--- a/tests/testthat/_snaps/tidy_as_ard.md
+++ b/tests/testthat/_snaps/tidy_as_ard.md
@@ -96,3 +96,40 @@
       14 Planned unit testing error!
       15 Planned unit testing error!
 
+---
+
+    Code
+      as.data.frame(tidy_as_ard(lst_tidy = eval_capture_conditions(dplyr::as_tibble(
+        stats::fisher.test(x = mtcars[["am"]], y = mtcars[["vs"]])[c("estimate",
+          "p.value", "method")])), tidy_result_names = c("estimate", "p.value",
+        "conf.low", "conf.high", "method", "alternative"), formals = formals(stats::fisher.test),
+      passed_args = list(), lst_ard_columns = list(context = "fishertest", group1 = "am",
+        variable = "vs")))
+    Output
+        group1 variable    context stat_name                          statistic
+      1     am       vs fishertest  estimate                           1.956055
+      2     am       vs fishertest   p.value                          0.4726974
+      3     am       vs fishertest    method Fisher's Exact Test for Count Data
+        statistic_fmt_fn warning error
+      1                1    NULL  NULL
+      2                1    NULL  NULL
+      3             NULL    NULL  NULL
+
+---
+
+    Code
+      as.data.frame(tidy_as_ard(lst_tidy = eval_capture_conditions(dplyr::as_tibble(
+        stats::fisher.test(x = mtcars[["am"]], y = mtcars[["vs"]])[c("estimate",
+          "p.value", "method")])), tidy_result_names = c("estimate", "p.value",
+        "conf.low", "conf.high", "method", "alternative"), passed_args = list(),
+      lst_ard_columns = list(context = "fishertest", group1 = "am", variable = "vs")))
+    Output
+        group1 variable    context stat_name                          statistic
+      1     am       vs fishertest  estimate                           1.956055
+      2     am       vs fishertest   p.value                          0.4726974
+      3     am       vs fishertest    method Fisher's Exact Test for Count Data
+        statistic_fmt_fn warning error
+      1                1    NULL  NULL
+      2                1    NULL  NULL
+      3             NULL    NULL  NULL
+

--- a/tests/testthat/_snaps/tidy_as_ard.md
+++ b/tests/testthat/_snaps/tidy_as_ard.md
@@ -99,37 +99,30 @@
 ---
 
     Code
-      as.data.frame(tidy_as_ard(lst_tidy = eval_capture_conditions(dplyr::as_tibble(
-        stats::fisher.test(x = mtcars[["am"]], y = mtcars[["vs"]])[c("estimate",
-          "p.value", "method")])), tidy_result_names = c("estimate", "p.value",
-        "conf.low", "conf.high", "method", "alternative"), formals = formals(stats::fisher.test),
-      passed_args = list(), lst_ard_columns = list(context = "fishertest", group1 = "am",
-        variable = "vs")))
+      dplyr::select(as.data.frame(tidy_as_ard(lst_tidy = eval_capture_conditions(
+        dplyr::as_tibble(stats::fisher.test(x = mtcars[["am"]], y = mtcars[["vs"]])[c(
+          "estimate", "p.value", "method")])), tidy_result_names = c("estimate",
+        "p.value", "conf.low", "conf.high", "method", "alternative"), formals = formals(
+        stats::fisher.test), passed_args = list(), lst_ard_columns = list(context = "fishertest",
+        group1 = "am", variable = "vs"))), c(group1, variable, statistic))
     Output
-        group1 variable    context stat_name                          statistic
-      1     am       vs fishertest  estimate                           1.956055
-      2     am       vs fishertest   p.value                          0.4726974
-      3     am       vs fishertest    method Fisher's Exact Test for Count Data
-        statistic_fmt_fn warning error
-      1                1    NULL  NULL
-      2                1    NULL  NULL
-      3             NULL    NULL  NULL
+        group1 variable                          statistic
+      1     am       vs                           1.956055
+      2     am       vs                          0.4726974
+      3     am       vs Fisher's Exact Test for Count Data
 
 ---
 
     Code
-      as.data.frame(tidy_as_ard(lst_tidy = eval_capture_conditions(dplyr::as_tibble(
-        stats::fisher.test(x = mtcars[["am"]], y = mtcars[["vs"]])[c("estimate",
-          "p.value", "method")])), tidy_result_names = c("estimate", "p.value",
-        "conf.low", "conf.high", "method", "alternative"), passed_args = list(),
-      lst_ard_columns = list(context = "fishertest", group1 = "am", variable = "vs")))
+      dplyr::select(as.data.frame(tidy_as_ard(lst_tidy = eval_capture_conditions(
+        dplyr::as_tibble(stats::fisher.test(x = mtcars[["am"]], y = mtcars[["vs"]])[c(
+          "estimate", "p.value", "method")])), tidy_result_names = c("estimate",
+        "p.value", "conf.low", "conf.high", "method", "alternative"), passed_args = list(),
+      lst_ard_columns = list(context = "fishertest", group1 = "am", variable = "vs"))),
+      c(group1, variable, statistic))
     Output
-        group1 variable    context stat_name                          statistic
-      1     am       vs fishertest  estimate                           1.956055
-      2     am       vs fishertest   p.value                          0.4726974
-      3     am       vs fishertest    method Fisher's Exact Test for Count Data
-        statistic_fmt_fn warning error
-      1                1    NULL  NULL
-      2                1    NULL  NULL
-      3             NULL    NULL  NULL
+        group1 variable                          statistic
+      1     am       vs                           1.956055
+      2     am       vs                          0.4726974
+      3     am       vs Fisher's Exact Test for Count Data
 

--- a/tests/testthat/test-tidy_as_ard.R
+++ b/tests/testthat/test-tidy_as_ard.R
@@ -57,7 +57,8 @@ test_that("tidy_as_ard() works", {
       passed_args = list(),
       lst_ard_columns = list(context = "fishertest", group1 = "am", variable = "vs")
     ) |>
-      as.data.frame()
+      as.data.frame() |>
+      dplyr::select(c(group1, variable, statistic))
   )
 
   # function works when `formals` argument is not passed.
@@ -73,6 +74,7 @@ test_that("tidy_as_ard() works", {
       passed_args = list(),
       lst_ard_columns = list(context = "fishertest", group1 = "am", variable = "vs")
     ) |>
-      as.data.frame()
+      as.data.frame() |>
+      dplyr::select(c(group1, variable, statistic))
   )
 })

--- a/tests/testthat/test-tidy_as_ard.R
+++ b/tests/testthat/test-tidy_as_ard.R
@@ -22,7 +22,7 @@ test_that("tidy_as_ard() works", {
       as.data.frame()
   )
 
-  # function works when proimary stats function errors
+  # function works when primary stats function errors
   expect_snapshot(
     tidy_as_ard(
       lst_tidy =
@@ -37,6 +37,39 @@ test_that("tidy_as_ard() works", {
           "conf.int", "conf.level", "simulate.p.value", "B"
         ),
       formals = formals(stats::fisher.test),
+      passed_args = list(),
+      lst_ard_columns = list(context = "fishertest", group1 = "am", variable = "vs")
+    ) |>
+      as.data.frame()
+  )
+
+  # function works when `fun_args_to_record` argument is not passed.
+  expect_snapshot(
+    tidy_as_ard(
+      lst_tidy =
+        eval_capture_conditions(
+          stats::fisher.test(x = mtcars[["am"]], y = mtcars[["vs"]])[c("estimate", "p.value", "method")] |>
+            dplyr::as_tibble()
+        ),
+      tidy_result_names =
+        c("estimate", "p.value", "conf.low", "conf.high", "method", "alternative"),
+      formals = formals(stats::fisher.test),
+      passed_args = list(),
+      lst_ard_columns = list(context = "fishertest", group1 = "am", variable = "vs")
+    ) |>
+      as.data.frame()
+  )
+
+  # function works when `formals` argument is not passed.
+  expect_snapshot(
+    tidy_as_ard(
+      lst_tidy =
+        eval_capture_conditions(
+          stats::fisher.test(x = mtcars[["am"]], y = mtcars[["vs"]])[c("estimate", "p.value", "method")] |>
+            dplyr::as_tibble()
+        ),
+      tidy_result_names =
+        c("estimate", "p.value", "conf.low", "conf.high", "method", "alternative"),
       passed_args = list(),
       lst_ard_columns = list(context = "fishertest", group1 = "am", variable = "vs")
     ) |>


### PR DESCRIPTION
Add default to `funs_to_record` argument in `tidy_as_ard()` (#171, @ayogasekaram)

error returned when argument is omitted downstream.

closes #171 

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] Approve Pull Request
- [x] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
