### PR TITLE
Removing cli styling from errors and warnings captured with `eval_capture_conditions()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,8 +7,8 @@ Authors@R: c(
     person("Becca", "Krouse", , "becca.z.krouse@gsk.com", role = "aut"),
     person("F. Hoffmann-La Roche AG", role = c("cph", "fnd"))
   )
-Description: Construct Clinical Data Interchange Standards Consortium
-    (CDISC) compliant Analysis Results Data objects. These objects are
+Description: Construct CDISC (Clinical Data Interchange Standards
+    Consortium) compliant Analysis Results Data objects. These objects are
     used and re-used to construct summary tables, visualizations, and
     written reports. The package also exports utilities for working with
     these objects and creating new Analysis Results Data objects.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # cards 0.1.0.9003
 
-* Styling from the {cli} pcakage are now removed from errors and warnings when they are captured with `eval_capture_conditions()`. Styling is removed with `cli::ansi_strip()`. (#129)
+* Styling from the {cli} package are now removed from errors and warnings when they are captured with `eval_capture_conditions()`. Styling is removed with `cli::ansi_strip()`. (#129)
 
 * Updated `is_pkg_installed()` and `check_pkg_installed()` to allow checks for more than package at a time. The `get_min_version_required()` function has also been updated to return a tibble instead of a list with attributes. (#201)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cards 0.1.0.9003
 
+* Styling from the {cli} pcakage are now removed from errors and warnings when they are captured with `eval_capture_conditions()`. Styling is removed with `cli::ansi_strip()`. (#129)
+
 * Updated `is_pkg_installed()` and `check_pkg_installed()` to allow checks for more than package at a time. The `get_min_version_required()` function has also been updated to return a tibble instead of a list with attributes. (#201)
 
 # cards 0.1.0

--- a/R/eval_capture_conditions.R
+++ b/R/eval_capture_conditions.R
@@ -8,7 +8,9 @@
 #'
 #' Messages are neither saved nor printed to the console.
 #'
-#' Evaluation is done via [eval_tidy()].
+#' Evaluation is done via [eval_tidy()]. If errors and warnings are produced
+#' using the `{cli}` package, the messages are processed with `cli::ansi_strip()`
+#' to remove styling from the message.
 #'
 #' @inheritParams rlang::eval_tidy
 #' @return a named list
@@ -52,12 +54,12 @@ eval_capture_conditions <- function(expr, data = NULL, env = caller_env()) {
       warning = function(w) {
         lst_result[["warning"]] <<-
           # using `c()` to capture all warnings
-          c(lst_result[["warning"]], conditionMessage(w))
+          c(lst_result[["warning"]], conditionMessage(w) |> cli::ansi_strip())
         invokeRestart("muffleWarning")
       }
     ),
     error = function(e) {
-      lst_result[["error"]] <<- conditionMessage(e)
+      lst_result[["error"]] <<- conditionMessage(e) |> cli::ansi_strip()
     }
   )
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -15,6 +15,7 @@ SDTM
 YAML
 ata
 cardx
+cli
 dplyr
 env
 esult

--- a/man/cards-package.Rd
+++ b/man/cards-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-Construct Clinical Data Interchange Standards Consortium (CDISC) compliant Analysis Results Data objects. These objects are used and re-used to construct summary tables, visualizations, and written reports. The package also exports utilities for working with these objects and creating new Analysis Results Data objects.
+Construct CDISC (Clinical Data Interchange Standards Consortium) compliant Analysis Results Data objects. These objects are used and re-used to construct summary tables, visualizations, and written reports. The package also exports utilities for working with these objects and creating new Analysis Results Data objects.
 }
 \seealso{
 Useful links:

--- a/man/eval_capture_conditions.Rd
+++ b/man/eval_capture_conditions.Rd
@@ -30,7 +30,9 @@ If there is an error, the result element will be \code{NULL}.
 
 Messages are neither saved nor printed to the console.
 
-Evaluation is done via \code{\link[=eval_tidy]{eval_tidy()}}.
+Evaluation is done via \code{\link[=eval_tidy]{eval_tidy()}}. If errors and warnings are produced
+using the \code{{cli}} package, the messages are processed with \code{cli::ansi_strip()}
+to remove styling from the message.
 }
 \examples{
 # function executes without error or warning

--- a/tests/testthat/_snaps/eval_capture_conditions.md
+++ b/tests/testthat/_snaps/eval_capture_conditions.md
@@ -51,8 +51,8 @@
 
     Code
       two_warn_foo <- (function() {
-        cli::cli_warn("BIG WARNING1")
-        cli::cli_warn("BIG WARNING2")
+        cli::cli_warn("{.emph BIG} WARNING1")
+        cli::cli_warn("{.emph BIG} WARNING2")
         TRUE
       })
       eval_capture_conditions(expr(two_warn_foo()))

--- a/tests/testthat/test-eval_capture_conditions.R
+++ b/tests/testthat/test-eval_capture_conditions.R
@@ -25,8 +25,8 @@ test_that("eval_capture_conditions() works", {
   # capture multiple warning
   expect_snapshot({
     two_warn_foo <- function() {
-      cli::cli_warn("BIG WARNING1")
-      cli::cli_warn("BIG WARNING2")
+      cli::cli_warn("{.emph BIG} WARNING1")
+      cli::cli_warn("{.emph BIG} WARNING2")
       TRUE
     }
     eval_capture_conditions(expr(two_warn_foo()))


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Styling from the {cli} pcakage are now removed from errors and warnings when they are captured with `eval_capture_conditions()`. Styling is removed with `cli::ansi_strip()`. (#129)

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #129 
closes #65 

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
