### PR TITLE
Improved messaging in `check_pkg_installed()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cards 0.1.0.9006
 
+* Improved messaging in `check_pkg_installed()` that incorporates the calling function name in the case of an error. (#205)
+
 * Styling from the {cli} package are now removed from errors and warnings when they are captured with `eval_capture_conditions()`. Styling is removed with `cli::ansi_strip()`. (#129)
 
 * Updated `is_pkg_installed()` and `check_pkg_installed()` to allow checks for more than package at a time. The `get_min_version_required()` function has also been updated to return a tibble instead of a list with attributes. (#201)

--- a/R/check_pkg_installed.R
+++ b/R/check_pkg_installed.R
@@ -54,17 +54,12 @@ check_pkg_installed <- function(pkg,
   df_pkg_min_version <-
     get_min_version_required(pkg = pkg, reference_pkg = reference_pkg, call = call)
 
-  # get fn name from which the function was called -----------------------------
-  fn <- error_call(call)
-
   # prompt user to install package ---------------------------------------------
   rlang::check_installed(
     pkg = df_pkg_min_version$pkg,
     version = df_pkg_min_version$version,
     compare = df_pkg_min_version$compare,
-    reason = switch(!is.null(fn),
-      glue::glue("for `{fn}`")
-    )
+    call = call
   ) |>
     # this can be removed after this issue is resolved https://github.com/r-lib/rlang/issues/1694
     suppressWarnings()

--- a/tests/testthat/_snaps/check_pkg_installed.md
+++ b/tests/testthat/_snaps/check_pkg_installed.md
@@ -1,0 +1,11 @@
+# check_pkg_installed() works
+
+    Code
+      user_facing_fn <- (function() {
+        check_pkg_installed(c("br000000m", "br1111111m"))
+      })
+      user_facing_fn()
+    Condition
+      Error in `user_facing_fn()`:
+      ! The packages "br000000m" and "br1111111m" are required.
+

--- a/tests/testthat/test-check_pkg_installed.R
+++ b/tests/testthat/test-check_pkg_installed.R
@@ -55,11 +55,13 @@ test_that("check_pkg_installed() works", {
   skip_if(interactive())
   # expect an error msg for pkg that doesn't exist
   # note: if interactive(), user will be invited to install the missing pkg
-  expect_snapshot({
-    user_facing_fn <- function() {
-      check_pkg_installed(c("br000000m", "br1111111m"))
-    }
-    user_facing_fn()},
+  expect_snapshot(
+    {
+      user_facing_fn <- function() {
+        check_pkg_installed(c("br000000m", "br1111111m"))
+      }
+      user_facing_fn()
+    },
     error = TRUE
   )
   expect_error(

--- a/tests/testthat/test-check_pkg_installed.R
+++ b/tests/testthat/test-check_pkg_installed.R
@@ -55,6 +55,13 @@ test_that("check_pkg_installed() works", {
   skip_if(interactive())
   # expect an error msg for pkg that doesn't exist
   # note: if interactive(), user will be invited to install the missing pkg
+  expect_snapshot({
+    user_facing_fn <- function() {
+      check_pkg_installed(c("br000000m", "br1111111m"))
+    }
+    user_facing_fn()},
+    error = TRUE
+  )
   expect_error(
     check_pkg_installed("br000000m")
   )

--- a/vignettes/articles/getting-started.Rmd
+++ b/vignettes/articles/getting-started.Rmd
@@ -67,13 +67,13 @@ df_continuous_ard |> head(5)
 To get the categorical variable summary, we will use the `ard_categorical()` function.
 
 ```{r}
-df_categoircal_ard <-
+df_categorical_ard <-
   ard_categorical(
     ADSL,
     by = ARM,
     variables = AGEGR1
   )
-df_categoircal_ard |> head(5)
+df_categorical_ard |> head(5)
 ```
 
 #### Dichotomous Summaries
@@ -99,7 +99,7 @@ As a last step, you can combine all of these objects into a single object using 
 ```{r}
 bind_ard(
   df_continuous_ard,
-  df_categoircal_ard,
+  df_categorical_ard,
   df_dichotomous_ard
 )
 ```


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Improved messaging in `check_pkg_installed()` that incorporates the calling function name in the case of an error. (#205)

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #205

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
