### PR TITLE
Returning `ard_stack(by)` summary stats

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cards 0.1.0.9008
 
+* Updated `ard_stack()` to return `n`, `p`, and `N` for the `by` variable when specified. Previously, it only returned `N` which is the same for all levels of the by variable. (#219)
+
 * Improved messaging in `check_pkg_installed()` that incorporates the calling function name in the case of an error. (#205)
 
 * Styling from the {cli} package are now removed from errors and warnings when they are captured with `eval_capture_conditions()`. Styling is removed with `cli::ansi_strip()`. (#129)

--- a/R/ard_stack.R
+++ b/R/ard_stack.R
@@ -1,9 +1,13 @@
 #' Stack ARDs
 #'
+#' @description
 #' Stack multiple ARD calls sharing common input `data` and `by` variables.
-#' Optionally incorporate additional information on represented variables (i.e.
-#' big N's, missingness, attributes) and/or tidy for use in displays with
-#' `shuffle_ard()`.
+#' Optionally incorporate additional information on represented variables, e.g.
+#' overall calculations, rates of missingness, attributes, or transform results
+#' with `shuffle_ard()`.
+#'
+#' If the `ard_stack(by)` argument is specified, a univariate tabulation of the
+#' by variable will also be returned.
 #'
 #' @param data (`data.frame`)\cr
 #'   a data frame

--- a/R/ard_stack.R
+++ b/R/ard_stack.R
@@ -82,8 +82,7 @@ ard_stack <- function(data,
       ard_list,
       ard_categorical(
         data = data,
-        variables = all_of(by),
-        statistic = everything() ~ categorical_summary_fns("N")
+        variables = all_of(by)
       )
     )
   } else {

--- a/man/ard_stack.Rd
+++ b/man/ard_stack.Rd
@@ -45,9 +45,12 @@ a transformed ARD data frame (of class 'card' if \code{.shuffle = FALSE})
 }
 \description{
 Stack multiple ARD calls sharing common input \code{data} and \code{by} variables.
-Optionally incorporate additional information on represented variables (i.e.
-big N's, missingness, attributes) and/or tidy for use in displays with
-\code{shuffle_ard()}.
+Optionally incorporate additional information on represented variables, e.g.
+overall calculations, rates of missingness, attributes, or transform results
+with \code{shuffle_ard()}.
+
+If the \code{ard_stack(by)} argument is specified, a univariate tabulation of the
+by variable will also be returned.
 }
 \examples{
 ard_stack(

--- a/tests/testthat/test-ard_stack.R
+++ b/tests/testthat/test-ard_stack.R
@@ -15,7 +15,7 @@ test_that("ard_stack() works", {
     bind_ard(
       ard_continuous(data = mtcars, by = "cyl", variables = "mpg"),
       ard_dichotomous(data = mtcars, by = "cyl", variables = "vs"),
-      ard_categorical(data = mtcars, variables = "cyl", statistic = everything() ~ categorical_summary_fns("N")),
+      ard_categorical(data = mtcars, variables = "cyl"),
       .order = TRUE
     ),
     ignore_function_env = TRUE
@@ -99,7 +99,7 @@ test_that("ard_stack() adding overalls", {
     bind_ard(
       ard_continuous(data = mtcars, by = "cyl", variables = "mpg"),
       ard_dichotomous(data = mtcars, by = "cyl", variables = "vs"),
-      ard_categorical(data = mtcars, variables = "cyl", statistic = everything() ~ categorical_summary_fns("N")),
+      ard_categorical(data = mtcars, variables = "cyl"),
       ard_continuous(data = mtcars, variables = "mpg"),
       ard_dichotomous(data = mtcars, variables = "vs"),
       .update = TRUE,
@@ -127,7 +127,7 @@ test_that("ard_stack() adding missing/attributes", {
     bind_ard(
       ard_continuous(data = mtcars, by = "cyl", variables = "mpg"),
       ard_dichotomous(data = mtcars, by = "cyl", variables = "vs"),
-      ard_categorical(data = mtcars, variables = "cyl", statistic = everything() ~ categorical_summary_fns("N")),
+      ard_categorical(data = mtcars, variables = "cyl"),
       ard_missing(data = mtcars, variables = c("cyl", "mpg", "vs")),
       ard_attributes(data = mtcars, variables = c("cyl", "mpg", "vs")),
       .update = TRUE,
@@ -154,9 +154,10 @@ test_that("ard_stack() .shuffle argument", {
     bind_ard(
       ard_continuous(data = mtcars, by = "cyl", variables = "mpg"),
       ard_dichotomous(data = mtcars, by = "cyl", variables = "vs"),
-      ard_categorical(data = mtcars, variables = "cyl", statistic = everything() ~ categorical_summary_fns("N")),
+      ard_categorical(data = mtcars, variables = "cyl"),
       .order = TRUE
     ) |>
       shuffle_ard()
   )
 })
+

--- a/tests/testthat/test-ard_stack.R
+++ b/tests/testthat/test-ard_stack.R
@@ -160,4 +160,3 @@ test_that("ard_stack() .shuffle argument", {
       shuffle_ard()
   )
 })
-


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Updated `ard_stack()` to return `n`, `p`, and `N` for the `by` variable when specified. Previously, it only returned `N` which is the same for all levels of the by variable. (#219)

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #219

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
