### PR TITLE
Adding `ard_heirarchicial(id)` argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cards 0.1.0.9014
 
+* Added the optional `ard_heirarchicial(id)` argument. When provided we check for duplicates across the column(s) supplied here. If duplicates are found, the user is warned that the percentages and denominators are not correct. (#214)
+
 * Corrected order that `ard_categorical` (strata) columns would appear in the ARD results. Previously, they appeared in the order they appeared in the original data, and now they are sorted properly. (#221)
 
 * Updated `ard_stack()` to return `n`, `p`, and `N` for the `by` variable when specified. Previously, it only returned `N` which is the same for all levels of the by variable. (#219)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # cards 0.1.0.9014
+
 * Corrected order that `ard_categorical` (strata) columns would appear in the ARD results. Previously, they appeared in the order they appeared in the original data, and now they are sorted properly. (#221)
 
 * Updated `ard_stack()` to return `n`, `p`, and `N` for the `by` variable when specified. Previously, it only returned `N` which is the same for all levels of the by variable. (#219)

--- a/R/ard_hierarchical.R
+++ b/R/ard_hierarchical.R
@@ -66,7 +66,7 @@ ard_hierarchical <- function(data,
   if (!is_empty(id) && anyDuplicated(data[id]) > 0L) {
     cli::cli_warn(c(
       "Duplicate rows found in data for the {.val {id}} column{?s}.",
-      "i" = "Percentages produced will not be correct."
+      "i" = "Percentages/Denominators are not correct."
     ))
   }
 

--- a/R/ard_hierarchical.R
+++ b/R/ard_hierarchical.R
@@ -14,6 +14,10 @@
 #' @param by ([`tidy-select`][dplyr::dplyr_tidy_select])\cr
 #'   variables to perform tabulations by. All combinations of the variables
 #'   specified here appear in results. Default is `dplyr::group_vars(data)`.
+#' @param id (([`tidy-select`][dplyr::dplyr_tidy_select])\cr)
+#'   an optional argument used to assert there are no duplicates with in the
+#'   column(s) passed here. For example, if `id=USUBJID` is passed, we will
+#'   add a check there are no duplicates in `data['USUBJID']`.
 #' @inheritParams ard_categorical
 #'
 #' @return an ARD data frame of class 'card'
@@ -41,7 +45,8 @@ ard_hierarchical <- function(data,
                              by = dplyr::group_vars(data),
                              statistic = everything() ~ categorical_summary_fns(),
                              denominator = NULL, fmt_fn = NULL,
-                             stat_label = everything() ~ default_stat_labels()) {
+                             stat_label = everything() ~ default_stat_labels(),
+                             id = NULL) {
   set_cli_abort_call()
 
   # check inputs ---------------------------------------------------------------
@@ -53,9 +58,17 @@ ard_hierarchical <- function(data,
   process_selectors(
     data,
     variables = {{ variables }},
-    by = {{ by }}
+    by = {{ by }},
+    id = {{ id }}
   )
   data <- dplyr::ungroup(data)
+
+  if (!is_empty(id) && anyDuplicated(data[id]) > 0L) {
+    cli::cli_warn(c(
+      "Duplicate rows found in data for the {.val {id}} column{?s}.",
+      "i" = "Percentages produced will not be correct."
+    ))
+  }
 
   # return empty tibble if no variables selected -------------------------------
   if (is_empty(variables)) {

--- a/man/ard_hierarchical.Rd
+++ b/man/ard_hierarchical.Rd
@@ -12,7 +12,8 @@ ard_hierarchical(
   statistic = everything() ~ categorical_summary_fns(),
   denominator = NULL,
   fmt_fn = NULL,
-  stat_label = everything() ~ default_stat_labels()
+  stat_label = everything() ~ default_stat_labels(),
+  id = NULL
 )
 
 ard_hierarchical_count(
@@ -55,6 +56,11 @@ a named list, a list of formulas, or a single formula where
 the list element is either a named list or a list of formulas defining the
 statistic labels, e.g. \code{everything() ~ list(n = "n", p = "pct")} or
 \code{everything() ~ list(n ~ "n", p ~ "pct")}.}
+
+\item{id}{((\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr)
+an optional argument used to assert there are no duplicates with in the
+column(s) passed here. For example, if \code{id=USUBJID} is passed, we will
+add a check there are no duplicates in \code{data['USUBJID']}.}
 }
 \value{
 an ARD data frame of class 'card'

--- a/tests/testthat/_snaps/ard_hierarchical.md
+++ b/tests/testthat/_snaps/ard_hierarchical.md
@@ -21,7 +21,7 @@
     Condition
       Warning:
       Duplicate rows found in data for the "USUBJID" column.
-      i Percentages produced will not be correct.
+      i Percentages/Denominators are not correct.
     Message
       {cards} data frame: 1 x 15
     Output
@@ -41,7 +41,7 @@
     Condition
       Warning:
       Duplicate rows found in data for the "USUBJID" and "SITEID" columns.
-      i Percentages produced will not be correct.
+      i Percentages/Denominators are not correct.
     Message
       {cards} data frame: 1 x 15
     Output

--- a/tests/testthat/_snaps/ard_hierarchical.md
+++ b/tests/testthat/_snaps/ard_hierarchical.md
@@ -13,6 +13,45 @@
     Output
       # A tibble: 0 x 0
 
+# ard_hierarchical(id) argument works
+
+    Code
+      head(ard_hierarchical(data = ADAE, variables = c(AESOC, AETERM), by = c(TRTA,
+        AESEV), denominator = dplyr::rename(ADSL, TRTA = ARM), id = USUBJID), 1L)
+    Condition
+      Warning:
+      Duplicate rows found in data for the "USUBJID" column.
+      i Percentages produced will not be correct.
+    Message
+      {cards} data frame: 1 x 15
+    Output
+        group1 group1_level group2 group2_level group3 group3_level variable
+      1   TRTA      Placebo  AESEV         MILD  AESOC    GASTROIN…   AETERM
+        variable_level stat_name stat_label stat
+      1      ABDOMINA…         n          n    0
+    Message
+      i 4 more variables: context, fmt_fn, warning, error
+
+---
+
+    Code
+      head(ard_hierarchical(data = ADAE, variables = c(AESOC, AETERM), by = c(TRTA,
+        AESEV), denominator = dplyr::rename(ADSL, TRTA = ARM), id = c(USUBJID, SITEID)),
+      1L)
+    Condition
+      Warning:
+      Duplicate rows found in data for the "USUBJID" and "SITEID" columns.
+      i Percentages produced will not be correct.
+    Message
+      {cards} data frame: 1 x 15
+    Output
+        group1 group1_level group2 group2_level group3 group3_level variable
+      1   TRTA      Placebo  AESEV         MILD  AESOC    GASTROIN…   AETERM
+        variable_level stat_name stat_label stat
+      1      ABDOMINA…         n          n    0
+    Message
+      i 4 more variables: context, fmt_fn, warning, error
+
 # ard_hierarchical_count() works without by variables
 
     Code

--- a/tests/testthat/test-ard_hierarchical.R
+++ b/tests/testthat/test-ard_hierarchical.R
@@ -103,7 +103,30 @@ test_that("ard_hierarchical() works without any variables", {
   )
 })
 
+test_that("ard_hierarchical(id) argument works", {
+  expect_snapshot(
+    ard_hierarchical(
+      data = ADAE,
+      variables = c(AESOC, AETERM),
+      by = c(TRTA, AESEV),
+      denominator = ADSL |> dplyr::rename(TRTA = ARM),
+      id = USUBJID
+    ) |>
+      head(1L)
+  )
 
+  # testing pluralization works in warning message
+  expect_snapshot(
+    ard_hierarchical(
+      data = ADAE,
+      variables = c(AESOC, AETERM),
+      by = c(TRTA, AESEV),
+      denominator = ADSL |> dplyr::rename(TRTA = ARM),
+      id = c(USUBJID, SITEID)
+    ) |>
+      head(1L)
+  )
+})
 
 # ard_hierarchical_count() -----------------------------------------------------
 test_that("ard_hierarchical_count() works without by variables", {


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Added the optional `ard_heirarchicial(id)` argument. When provided we check for duplicates across the column(s) supplied here. If duplicates are found, the user is warned that the percentages and denominators are not correct. (#214)

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #214

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
