### PR TITLE
Create .gitlab-ci.yml for internal automations

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,4 @@
 ^\.DS_Store$
 ^cran-comments\.md$
 ^CRAN-SUBMISSION$
+^\.gitlab-ci\.yml$

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,6 @@
+---
+
+include:
+  - project: 'nest/automation/gitlab-shared-library'
+    ref: main
+    file: R/R_NEST_min.gitlab-ci.yml


### PR DESCRIPTION
Adds a `.gitlab-ci.yml`. This shouldn't affect the package functionality. It simply enables internal automation on sync.