### PR TITLE
Passing `ard_stack(by)` arg to `ard_missing()` when `.missing=TRUE`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cards 0.1.0.9023
 
+* Bug fix where `ard_stack(by)` argument was not passed to `ard_missing()` when `ard_stack(.missing=TRUE)`. (#244)
+
 * The `print_ard_conditions()` function has been updated to no longer error out if the ARD object does not have `"error"` or `"warning"` columns. (#240)
 
 * Added the optional `ard_heirarchicial(id)` argument. When provided we check for duplicates across the column(s) supplied here. If duplicates are found, the user is warned that the percentages and denominators are not correct. (#214)

--- a/R/ard_stack.R
+++ b/R/ard_stack.R
@@ -69,8 +69,10 @@ ard_stack <- function(data,
   check_scalar_logical(.shuffle)
 
   if (is_empty(by) && isTRUE(.overall)) {
-    cli::cli_abort("Cannot specify {.arg by} argument with {.code .overall=TRUE}.",
-                   call = get_cli_abort_call())
+    cli::cli_abort(
+      "Argument {.arg by} cannot be empty when {.code .overall=TRUE}.",
+      call = get_cli_abort_call()
+    )
   }
 
   # evaluate the dots using common `data` and `by`

--- a/R/ard_stack.R
+++ b/R/ard_stack.R
@@ -71,7 +71,8 @@ ard_stack <- function(data,
   if (is_empty(by) && isTRUE(.overall)) {
     cli::cli_inform(
       c("The {.arg by} argument should be specified when using {.code .overall=TRUE}.",
-        i = "Setting {.code ard_stack(.overall=FALSE)}.")
+        i = "Setting {.code ard_stack(.overall=FALSE)}."
+      )
     )
     .overall <- FALSE
   }

--- a/R/ard_stack.R
+++ b/R/ard_stack.R
@@ -69,10 +69,11 @@ ard_stack <- function(data,
   check_scalar_logical(.shuffle)
 
   if (is_empty(by) && isTRUE(.overall)) {
-    cli::cli_abort(
-      "Argument {.arg by} must be specified when {.code .overall=TRUE}.",
-      call = get_cli_abort_call()
+    cli::cli_inform(
+      c("The {.arg by} argument should be specified when using {.code .overall=TRUE}.",
+        i = "Setting {.code ard_stack(.overall=FALSE)}.")
     )
+    .overall <- FALSE
   }
 
   # evaluate the dots using common `data` and `by`

--- a/R/ard_stack.R
+++ b/R/ard_stack.R
@@ -57,10 +57,7 @@ ard_stack <- function(data,
   set_cli_abort_call()
 
   # process arguments ----------------------------------------------------------
-  process_selectors(
-    data,
-    by = {{ by }}
-  )
+  process_selectors(data, by = {{ by }})
 
   # check inputs ---------------------------------------------------------------
   check_not_missing(data)
@@ -70,6 +67,11 @@ ard_stack <- function(data,
   check_scalar_logical(.missing)
   check_scalar_logical(.attributes)
   check_scalar_logical(.shuffle)
+
+  if (is_empty(by) && isTRUE(.overall)) {
+    cli::cli_abort("Cannot specify {.arg by} argument with {.code .overall=TRUE}.",
+                   call = get_cli_abort_call())
+  }
 
   # evaluate the dots using common `data` and `by`
   ard_list <- .eval_ard_calls(data, by, ...)
@@ -96,21 +98,27 @@ ard_stack <- function(data,
   }
 
   # get all variables represented
-  variables <- unique(ard_full$variable)
+  variables <- unique(ard_full$variable) |> setdiff(by)
 
   # missingness
   if (isTRUE(.missing)) {
     ard_full <- bind_ard(
       ard_full,
-      ard_missing(data = data, variables = all_of(variables))
+      ard_missing(data = data, by = any_of(by), variables = all_of(variables))
     )
+    if (!is_empty(by) && isTRUE(.overall)) {
+      ard_full <- bind_ard(
+        ard_full,
+        ard_missing(data = data, by = character(0L), variables = all_of(variables))
+      )
+    }
   }
 
   # attributes
   if (isTRUE(.attributes)) {
     ard_full <- bind_ard(
       ard_full,
-      ard_attributes(data, variables = all_of(variables))
+      ard_attributes(data, variables = all_of(c(variables, by)))
     )
   }
 

--- a/R/ard_stack.R
+++ b/R/ard_stack.R
@@ -70,7 +70,7 @@ ard_stack <- function(data,
 
   if (is_empty(by) && isTRUE(.overall)) {
     cli::cli_abort(
-      "Argument {.arg by} cannot be empty when {.code .overall=TRUE}.",
+      "Argument {.arg by} must be specified when {.code .overall=TRUE}.",
       call = get_cli_abort_call()
     )
   }

--- a/tests/testthat/_snaps/ard_stack.md
+++ b/tests/testthat/_snaps/ard_stack.md
@@ -1,0 +1,9 @@
+# ard_stack() error messaging
+
+    Code
+      ard_stack(data = mtcars, by = NULL, ard_continuous(variables = "mpg"),
+      .overall = TRUE)
+    Condition
+      Error in `ard_stack()`:
+      ! Argument `by` must be specified when `.overall=TRUE`.
+

--- a/tests/testthat/_snaps/ard_stack.md
+++ b/tests/testthat/_snaps/ard_stack.md
@@ -1,9 +1,15 @@
-# ard_stack() error messaging
+# ard_stack() messaging
 
     Code
-      ard_stack(data = mtcars, by = NULL, ard_continuous(variables = "mpg"),
-      .overall = TRUE)
-    Condition
-      Error in `ard_stack()`:
-      ! Argument `by` must be specified when `.overall=TRUE`.
+      head(ard_stack(data = mtcars, by = NULL, ard_continuous(variables = "mpg"),
+      .overall = TRUE), 1L)
+    Message
+      The `by` argument should be specified when using `.overall=TRUE`.
+      i Setting `ard_stack(.overall=FALSE)`.
+      {cards} data frame: 1 x 8
+    Output
+        variable   context stat_name stat_label stat fmt_fn
+      1      mpg continuo…         N          N   32      0
+    Message
+      i 2 more variables: warning, error
 

--- a/tests/testthat/test-ard_stack.R
+++ b/tests/testthat/test-ard_stack.R
@@ -134,6 +134,38 @@ test_that("ard_stack() adding missing/attributes", {
       .order = TRUE
     )
   )
+
+  # including `.overall=TRUE`
+  expect_error(
+    ard_test_overall <- ard_stack(
+      data = mtcars,
+      by = "cyl",
+      ard_continuous(variables = "mpg"),
+      ard_dichotomous(variables = "vs"),
+      .missing = TRUE,
+      .overall = TRUE,
+      .attributes = TRUE
+    ),
+    NA
+  )
+
+  expect_equal(
+    ard_test_overall,
+    bind_ard(
+      ard_continuous(data = mtcars, by = "cyl", variables = "mpg"),
+      ard_dichotomous(data = mtcars, by = "cyl", variables = "vs"),
+      ard_missing(data = mtcars, by = "cyl", variables = c("mpg", "vs")),
+
+      ard_continuous(data = mtcars, variables = "mpg"),
+      ard_dichotomous(data = mtcars, variables = "vs"),
+      ard_missing(data = mtcars, variables = c("mpg", "vs")),
+
+      ard_categorical(data = mtcars, variables = "cyl"),
+      ard_attributes(mtcars, variables = c("cyl", "mpg", "vs")),
+      .update = TRUE,
+      .order = TRUE
+    )
+  )
 })
 
 
@@ -158,5 +190,17 @@ test_that("ard_stack() .shuffle argument", {
       .order = TRUE
     ) |>
       shuffle_ard()
+  )
+})
+
+test_that("ard_stack() error messaging", {
+  expect_snapshot(
+    error = TRUE,
+    ard_stack(
+      data = mtcars,
+      by = NULL,
+      ard_continuous(variables = "mpg"),
+      .overall = TRUE
+    )
   )
 })

--- a/tests/testthat/test-ard_stack.R
+++ b/tests/testthat/test-ard_stack.R
@@ -128,7 +128,7 @@ test_that("ard_stack() adding missing/attributes", {
       ard_continuous(data = mtcars, by = "cyl", variables = "mpg"),
       ard_dichotomous(data = mtcars, by = "cyl", variables = "vs"),
       ard_categorical(data = mtcars, variables = "cyl"),
-      ard_missing(data = mtcars, variables = c("cyl", "mpg", "vs")),
+      ard_missing(data = mtcars, by = "cyl", variables = c("mpg", "vs")),
       ard_attributes(mtcars, variables = c("cyl", "mpg", "vs")),
       .update = TRUE,
       .order = TRUE

--- a/tests/testthat/test-ard_stack.R
+++ b/tests/testthat/test-ard_stack.R
@@ -191,14 +191,14 @@ test_that("ard_stack() .shuffle argument", {
   )
 })
 
-test_that("ard_stack() error messaging", {
+test_that("ard_stack() messaging", {
   expect_snapshot(
-    error = TRUE,
     ard_stack(
       data = mtcars,
       by = NULL,
       ard_continuous(variables = "mpg"),
       .overall = TRUE
-    )
+    ) |>
+      head(1L)
   )
 })

--- a/tests/testthat/test-ard_stack.R
+++ b/tests/testthat/test-ard_stack.R
@@ -155,11 +155,9 @@ test_that("ard_stack() adding missing/attributes", {
       ard_continuous(data = mtcars, by = "cyl", variables = "mpg"),
       ard_dichotomous(data = mtcars, by = "cyl", variables = "vs"),
       ard_missing(data = mtcars, by = "cyl", variables = c("mpg", "vs")),
-
       ard_continuous(data = mtcars, variables = "mpg"),
       ard_dichotomous(data = mtcars, variables = "vs"),
       ard_missing(data = mtcars, variables = c("mpg", "vs")),
-
       ard_categorical(data = mtcars, variables = "cyl"),
       ard_attributes(mtcars, variables = c("cyl", "mpg", "vs")),
       .update = TRUE,


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Bug fix where `ard_stack(by)` argument was not passed to `ard_missing()` when `ard_stack(.missing=TRUE)`. (#244)

Provide more detail here as needed.

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #244 

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
