### PR TITLE
`ard_stack(by)` argument has been renamed to `".by"`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cards 0.1.0.9028
 
+* The `ard_stack(by)` argument has been renamed to `".by"` and its location moved to after the dots inputs, e.g. `ard_stack(..., .by)`. (#243)
+
 * Added `check_ard_structure(column_order, method)` arguments to the function to check for column ordering and whether result contains a `stat_name='method'` row.
 
 * Converting `ard_*()` functions and other helpers to S3 generics to make them extendable. (#227) 

--- a/R/ard_stack.R
+++ b/R/ard_stack.R
@@ -156,7 +156,7 @@ ard_stack <- function(data,
 #' @examples
 #' cards:::.eval_ard_calls(
 #'   data = ADSL,
-#'   by = "ARM",
+#'   .by = "ARM",
 #'   ard_categorical(variables = "AGEGR1"),
 #'   ard_continuous(variables = "AGE")
 #' )

--- a/R/ard_stack.R
+++ b/R/ard_stack.R
@@ -11,7 +11,7 @@
 #'
 #' @param data (`data.frame`)\cr
 #'   a data frame
-#' @param by ([`tidy-select`][dplyr::dplyr_tidy_select])\cr
+#' @param .by ([`tidy-select`][dplyr::dplyr_tidy_select])\cr
 #'   columns to tabulate by in the series of ARD function calls
 #' @param ... ([`dynamic-dots`][dyn-dots])\cr
 #'   Series of ARD function calls to be run and stacked
@@ -34,22 +34,24 @@
 #' @examples
 #' ard_stack(
 #'   data = ADSL,
-#'   by = "ARM",
 #'   ard_categorical(variables = "AGEGR1"),
-#'   ard_continuous(variables = "AGE")
+#'   ard_continuous(variables = "AGE"),
+#'   .by = "ARM",
+#'   .overall = TRUE,
+#'   .attributes = TRUE
 #' )
 #'
 #' ard_stack(
 #'   data = ADSL,
-#'   by = "ARM",
 #'   ard_categorical(variables = "AGEGR1"),
 #'   ard_continuous(variables = "AGE"),
+#'   .by = "ARM",
 #'   .shuffle = TRUE
 #' )
 #'
 ard_stack <- function(data,
-                      by = NULL,
                       ...,
+                      .by = NULL,
                       .overall = FALSE,
                       .missing = FALSE,
                       .attributes = FALSE,
@@ -57,20 +59,20 @@ ard_stack <- function(data,
   set_cli_abort_call()
 
   # process arguments ----------------------------------------------------------
-  process_selectors(data, by = {{ by }})
+  process_selectors(data, .by = {{ .by }})
 
   # check inputs ---------------------------------------------------------------
   check_not_missing(data)
-  check_data_frame(x = data)
+  check_data_frame(data)
 
   check_scalar_logical(.overall)
   check_scalar_logical(.missing)
   check_scalar_logical(.attributes)
   check_scalar_logical(.shuffle)
 
-  if (is_empty(by) && isTRUE(.overall)) {
+  if (is_empty(.by) && isTRUE(.overall)) {
     cli::cli_inform(
-      c("The {.arg by} argument should be specified when using {.code .overall=TRUE}.",
+      c("The {.arg .by} argument should be specified when using {.code .overall=TRUE}.",
         i = "Setting {.code ard_stack(.overall=FALSE)}."
       )
     )
@@ -78,13 +80,13 @@ ard_stack <- function(data,
   }
 
   # evaluate the dots using common `data` and `by`
-  ard_list <- .eval_ard_calls(data, by, ...)
+  ard_list <- .eval_ard_calls(data, .by, ...)
 
   # add overall
   if (isTRUE(.overall)) {
     ard_list <- c(
       ard_list,
-      .eval_ard_calls(data, by = character(0), ...)
+      .eval_ard_calls(data, .by = character(0), ...)
     )
   }
 
@@ -94,7 +96,7 @@ ard_stack <- function(data,
       ard_list,
       ard_categorical(
         data = data,
-        variables = all_of(by)
+        variables = all_of(.by)
       )
     )
   } else {
@@ -102,13 +104,13 @@ ard_stack <- function(data,
   }
 
   # get all variables represented
-  variables <- unique(ard_full$variable) |> setdiff(by)
+  variables <- unique(ard_full$variable) |> setdiff(.by)
 
   # missingness
   if (isTRUE(.missing)) {
     ard_full <- bind_ard(
       ard_full,
-      ard_missing(data = data, by = any_of(by), variables = all_of(variables))
+      ard_missing(data = data, by = any_of(.by), variables = all_of(variables))
     )
     if (!is_empty(by) && isTRUE(.overall)) {
       ard_full <- bind_ard(
@@ -122,7 +124,7 @@ ard_stack <- function(data,
   if (isTRUE(.attributes)) {
     ard_full <- bind_ard(
       ard_full,
-      ard_attributes(data, variables = all_of(c(variables, by)))
+      ard_attributes(data, variables = all_of(c(variables, .by)))
     )
   }
 
@@ -143,7 +145,7 @@ ard_stack <- function(data,
 #'
 #' @param data (`data.frame`)\cr
 #'   a data frame
-#' @param by ([`tidy-select`][dplyr::dplyr_tidy_select])\cr
+#' @param .by ([`tidy-select`][dplyr::dplyr_tidy_select])\cr
 #'   columns to tabulate by in the series of ARD function calls
 #' @param ... ([`dynamic-dots`][dyn-dots])\cr
 #'   Series of ARD function calls to be run and stacked
@@ -158,7 +160,7 @@ ard_stack <- function(data,
 #'   ard_categorical(variables = "AGEGR1"),
 #'   ard_continuous(variables = "AGE")
 #' )
-.eval_ard_calls <- function(data, by, ...) {
+.eval_ard_calls <- function(data, .by, ...) {
   # capture quosures -----------------------------------------------------------
   dots <- enquos(...)
 
@@ -171,7 +173,7 @@ ard_stack <- function(data,
       x_fn <- call_name(x_rhs)
       x_args <- call_args(x_rhs)
 
-      do.call(x_fn, c(list(data = data, by = by), x_args), envir = attr(x, ".Environment"))
+      do.call(x_fn, c(list(data = data, by = .by), x_args), envir = attr(x, ".Environment"))
     }
   )
 }

--- a/man/ard_stack.Rd
+++ b/man/ard_stack.Rd
@@ -6,8 +6,8 @@
 \usage{
 ard_stack(
   data,
-  by = NULL,
   ...,
+  .by = NULL,
   .overall = FALSE,
   .missing = FALSE,
   .attributes = FALSE,
@@ -18,11 +18,11 @@ ard_stack(
 \item{data}{(\code{data.frame})\cr
 a data frame}
 
-\item{by}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
-columns to tabulate by in the series of ARD function calls}
-
 \item{...}{(\code{\link[=dyn-dots]{dynamic-dots}})\cr
 Series of ARD function calls to be run and stacked}
+
+\item{.by}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
+columns to tabulate by in the series of ARD function calls}
 
 \item{.overall}{(\code{logical})\cr logical indicating whether overall statistics
 should be calculated (i.e. re-run all \verb{ard_*()} calls with \code{by=NULL}).
@@ -55,16 +55,18 @@ by variable will also be returned.
 \examples{
 ard_stack(
   data = ADSL,
-  by = "ARM",
   ard_categorical(variables = "AGEGR1"),
-  ard_continuous(variables = "AGE")
+  ard_continuous(variables = "AGE"),
+  .by = "ARM",
+  .overall = TRUE,
+  .attributes = TRUE
 )
 
 ard_stack(
   data = ADSL,
-  by = "ARM",
   ard_categorical(variables = "AGEGR1"),
   ard_continuous(variables = "AGE"),
+  .by = "ARM",
   .shuffle = TRUE
 )
 

--- a/man/dot-eval_ard_calls.Rd
+++ b/man/dot-eval_ard_calls.Rd
@@ -25,7 +25,7 @@ Evaluate the \verb{ard_*()} function calls
 \examples{
 cards:::.eval_ard_calls(
   data = ADSL,
-  by = "ARM",
+  .by = "ARM",
   ard_categorical(variables = "AGEGR1"),
   ard_continuous(variables = "AGE")
 )

--- a/man/dot-eval_ard_calls.Rd
+++ b/man/dot-eval_ard_calls.Rd
@@ -4,13 +4,13 @@
 \alias{.eval_ard_calls}
 \title{Evaluate the \verb{ard_*()} function calls}
 \usage{
-.eval_ard_calls(data, by, ...)
+.eval_ard_calls(data, .by, ...)
 }
 \arguments{
 \item{data}{(\code{data.frame})\cr
 a data frame}
 
-\item{by}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
+\item{.by}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
 columns to tabulate by in the series of ARD function calls}
 
 \item{...}{(\code{\link[=dyn-dots]{dynamic-dots}})\cr

--- a/tests/testthat/_snaps/ard_stack.md
+++ b/tests/testthat/_snaps/ard_stack.md
@@ -1,10 +1,10 @@
 # ard_stack() messaging
 
     Code
-      head(ard_stack(data = mtcars, by = NULL, ard_continuous(variables = "mpg"),
-      .overall = TRUE), 1L)
+      head(ard_stack(data = mtcars, ard_continuous(variables = "mpg"), .overall = TRUE),
+      1L)
     Message
-      The `by` argument should be specified when using `.overall=TRUE`.
+      The `.by` argument should be specified when using `.overall=TRUE`.
       i Setting `ard_stack(.overall=FALSE)`.
       {cards} data frame: 1 x 8
     Output

--- a/tests/testthat/test-ard_stack.R
+++ b/tests/testthat/test-ard_stack.R
@@ -3,7 +3,7 @@ test_that("ard_stack() works", {
   expect_error(
     ard1 <- ard_stack(
       data = mtcars,
-      by = "cyl",
+      .by = "cyl",
       ard_continuous(variables = "mpg"),
       ard_dichotomous(variables = "vs")
     ),
@@ -26,7 +26,7 @@ test_that("ard_stack() works", {
     ard1,
     ard_stack(
       data = mtcars,
-      by = cyl,
+      .by = cyl,
       ard_continuous(variables = mpg),
       ard_dichotomous(variables = vs)
     ),
@@ -42,7 +42,7 @@ test_that("ard_stack() works", {
     ard1,
     ard_stack(
       data = mtcars2,
-      by = all_of(by),
+      .by = all_of(by),
       ard_continuous(variables = all_of(var_cont)),
       ard_dichotomous(variables = all_of(var_cat))
     )
@@ -52,7 +52,7 @@ test_that("ard_stack() works", {
   expect_error(
     ard2 <- ard_stack(
       data = mtcars,
-      by = NULL,
+      .by = NULL,
       ard_continuous(variables = "mpg"),
       ard_dichotomous(variables = "vs")
     ),
@@ -74,7 +74,6 @@ test_that("ard_stack() works", {
     ard2,
     ard_stack(
       data = mtcars2,
-      by = NULL,
       ard_continuous(variables = all_of(var_cont)),
       ard_dichotomous(variables = all_of(var_cat))
     )
@@ -85,7 +84,7 @@ test_that("ard_stack() adding overalls", {
   expect_error(
     ard_test <- ard_stack(
       data = mtcars,
-      by = "cyl",
+      .by = "cyl",
       ard_continuous(variables = "mpg"),
       ard_dichotomous(variables = "vs"),
       .overall = TRUE
@@ -113,7 +112,7 @@ test_that("ard_stack() adding missing/attributes", {
   expect_error(
     ard_test <- ard_stack(
       data = mtcars,
-      by = "cyl",
+      .by = "cyl",
       ard_continuous(variables = "mpg"),
       ard_dichotomous(variables = "vs"),
       .missing = TRUE,
@@ -139,7 +138,7 @@ test_that("ard_stack() adding missing/attributes", {
   expect_error(
     ard_test_overall <- ard_stack(
       data = mtcars,
-      by = "cyl",
+      .by = "cyl",
       ard_continuous(variables = "mpg"),
       ard_dichotomous(variables = "vs"),
       .missing = TRUE,
@@ -171,7 +170,7 @@ test_that("ard_stack() .shuffle argument", {
   expect_error(
     ard_test <- ard_stack(
       data = mtcars,
-      by = "cyl",
+      .by = "cyl",
       ard_continuous(variables = "mpg"),
       ard_dichotomous(variables = "vs"),
       .shuffle = TRUE
@@ -195,7 +194,6 @@ test_that("ard_stack() messaging", {
   expect_snapshot(
     ard_stack(
       data = mtcars,
-      by = NULL,
       ard_continuous(variables = "mpg"),
       .overall = TRUE
     ) |>

--- a/vignettes/articles/getting-started.Rmd
+++ b/vignettes/articles/getting-started.Rmd
@@ -114,7 +114,7 @@ Moreover, we will also be returned the univariate tabulation of the `by` variabl
 ```{r}
 ard_stack(
   data = ADSL,
-  by = ARM,
+  .by = ARM,
   ard_continuous(
     variables = AGE,
     statistic = ~ continuous_summary_fns(c("median", "p25", "p75", "mean", "sd", "min", "max"))


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* The `ard_stack(by)` argument has been renamed to `".by"` and its location moved to after the dots inputs, e.g. `ard_stack(..., .by)`. (#243)

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #243

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
