### PR TITLE
fix in `ard_stack()` when calls to functions were namespaced

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cards 0.1.0.9028
 
+* Bug fix in `ard_stack()` when calls to functions were namespaced. (#242)
+
 * Added `check_ard_structure(column_order, method)` arguments to the function to check for column ordering and whether result contains a `stat_name='method'` row.
 
 * Converting `ard_*()` functions and other helpers to S3 generics to make them extendable. (#227) 

--- a/R/ard_stack.R
+++ b/R/ard_stack.R
@@ -167,11 +167,25 @@ ard_stack <- function(data,
   lapply(
     dots,
     function(x) {
-      x_rhs <- f_rhs(x)
-      x_fn <- call_name(x_rhs)
-      x_args <- call_args(x_rhs)
+      if (!is_call_simple(x)) {
+        cli::cli_abort(
+          "{.fun cards::ard_stack} works with {.help [simple calls](rlang::call_name)}
+           and {.code {as_label(x)}} is not simple.",
+          call = get_cli_abort_call()
+        )
+      }
+      x_ns <- call_ns(x)
+      x_fn <- call_name(x)
+      x_args <- call_args(x)
 
-      do.call(x_fn, c(list(data = data, by = by), x_args), envir = attr(x, ".Environment"))
+      # if a function was namespaced, then grab function from that pkg's Namespace
+      # styler: off
+      final_fn <-
+        if (is.null(x_ns)) x_fn
+        else get(x_fn, envir = asNamespace(x_ns))
+      # styler: on
+
+      do.call(final_fn, c(list(data = data, by = by), x_args), envir = attr(x, ".Environment"))
     }
   )
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -27,6 +27,7 @@ httr
 jsonlite
 mis
 nalysis
+namespaced
 nonmiss
 pre
 quosures

--- a/tests/testthat/_snaps/ard_stack.md
+++ b/tests/testthat/_snaps/ard_stack.md
@@ -18,7 +18,7 @@
     Code
       complex_call <- list()
       complex_call$ard_continuous <- ard_continuous
-      ard_stack(data = mtcars, by = am, complex_call$ard_continuous(variables = "mpg"),
+      ard_stack(data = mtcars, .by = am, complex_call$ard_continuous(variables = "mpg"),
       )
     Condition
       Error in `ard_stack()`:

--- a/tests/testthat/_snaps/ard_stack.md
+++ b/tests/testthat/_snaps/ard_stack.md
@@ -13,3 +13,14 @@
     Message
       i 2 more variables: warning, error
 
+# ard_stack() complex call error
+
+    Code
+      complex_call <- list()
+      complex_call$ard_continuous <- ard_continuous
+      ard_stack(data = mtcars, by = am, complex_call$ard_continuous(variables = "mpg"),
+      )
+    Condition
+      Error in `ard_stack()`:
+      ! `cards::ard_stack()` works with simple calls (`?rlang::call_name()`) and `complex_call$ard_continuous(variables = "mpg")` is not simple.
+

--- a/tests/testthat/test-ard_stack.R
+++ b/tests/testthat/test-ard_stack.R
@@ -220,14 +220,16 @@ test_that("ard_stack() messaging", {
 })
 
 test_that("ard_stack() complex call error", {
-  expect_snapshot({
-    complex_call <- list()
-    complex_call$ard_continuous <- ard_continuous
-    ard_stack(
-      data = mtcars,
-      by = am,
-      complex_call$ard_continuous(variables = "mpg"),
-    )},
+  expect_snapshot(
+    {
+      complex_call <- list()
+      complex_call$ard_continuous <- ard_continuous
+      ard_stack(
+        data = mtcars,
+        by = am,
+        complex_call$ard_continuous(variables = "mpg"),
+      )
+    },
     error = TRUE
   )
 })

--- a/tests/testthat/test-ard_stack.R
+++ b/tests/testthat/test-ard_stack.R
@@ -191,6 +191,22 @@ test_that("ard_stack() .shuffle argument", {
   )
 })
 
+
+test_that("ard_stack() works with namespaced functions", {
+  expect_equal(
+    ard_stack(
+      data = mtcars,
+      by = NULL,
+      cards::ard_continuous(variables = "mpg")
+    ),
+    ard_stack(
+      data = mtcars,
+      by = NULL,
+      ard_continuous(variables = "mpg")
+    )
+  )
+})
+
 test_that("ard_stack() messaging", {
   expect_snapshot(
     ard_stack(
@@ -200,5 +216,18 @@ test_that("ard_stack() messaging", {
       .overall = TRUE
     ) |>
       head(1L)
+  )
+})
+
+test_that("ard_stack() complex call error", {
+  expect_snapshot({
+    complex_call <- list()
+    complex_call$ard_continuous <- ard_continuous
+    ard_stack(
+      data = mtcars,
+      by = am,
+      complex_call$ard_continuous(variables = "mpg"),
+    )},
+    error = TRUE
   )
 })

--- a/tests/testthat/test-ard_stack.R
+++ b/tests/testthat/test-ard_stack.R
@@ -195,12 +195,10 @@ test_that("ard_stack() works with namespaced functions", {
   expect_equal(
     ard_stack(
       data = mtcars,
-      by = NULL,
       cards::ard_continuous(variables = "mpg")
     ),
     ard_stack(
       data = mtcars,
-      by = NULL,
       ard_continuous(variables = "mpg")
     )
   )
@@ -224,7 +222,7 @@ test_that("ard_stack() complex call error", {
       complex_call$ard_continuous <- ard_continuous
       ard_stack(
         data = mtcars,
-        by = am,
+        .by = am,
         complex_call$ard_continuous(variables = "mpg"),
       )
     },


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Bug fix in `ard_stack()` when calls to functions were namespaced. (#242)

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #242 

@bzkrouse have you come across a method for testing if a function works if the package is not loaded? That could be a good test to add too.

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
