### PR TITLE
adding better error message for `ard_stack(.by)` when mis-specified with `ard_stack(by)`

### DIFF
--- a/R/ard_stack.R
+++ b/R/ard_stack.R
@@ -178,10 +178,18 @@ ard_stack <- function(data,
 
 
   # run the ARD calls -------------------------------------------------------
-  lapply(
+  imap(
     dots,
-    function(x) {
+    function(x, y) {
       if (!is_call_simple(x)) {
+        if (identical(y, "by")) {
+          cli::cli_abort(
+            c("Cannot evaluate expression {.code {y} = {quo_squash(x)}}.",
+              i = "Did you mean {.code .{y} = {quo_squash(x)}}?"),
+            call = get_cli_abort_call()
+          )
+        }
+
         cli::cli_abort(
           "{.fun cards::ard_stack} works with {.help [simple calls](rlang::call_name)}
            and {.code {as_label(x)}} is not simple.",

--- a/R/ard_stack.R
+++ b/R/ard_stack.R
@@ -185,7 +185,8 @@ ard_stack <- function(data,
         if (identical(y, "by")) {
           cli::cli_abort(
             c("Cannot evaluate expression {.code {y} = {quo_squash(x)}}.",
-              i = "Did you mean {.code .{y} = {quo_squash(x)}}?"),
+              i = "Did you mean {.code .{y} = {quo_squash(x)}}?"
+            ),
             call = get_cli_abort_call()
           )
         }

--- a/tests/testthat/_snaps/ard_stack.md
+++ b/tests/testthat/_snaps/ard_stack.md
@@ -13,6 +13,15 @@
     Message
       i 2 more variables: warning, error
 
+---
+
+    Code
+      ard_stack(ADSL, by = "ARM", ard_continuous(variables = AGE))
+    Condition
+      Error in `ard_stack()`:
+      ! Cannot evaluate expression `by = ARM`.
+      i Did you mean `.by = ARM`?
+
 # ard_stack() complex call error
 
     Code

--- a/tests/testthat/test-ard_stack.R
+++ b/tests/testthat/test-ard_stack.R
@@ -226,6 +226,12 @@ test_that("ard_stack() messaging", {
     ) |>
       head(1L)
   )
+
+  # by argument doesn't include period in front
+  expect_snapshot(
+    error = TRUE,
+    ard_stack(ADSL, by = "ARM", ard_continuous(variables = AGE))
+  )
 })
 
 test_that("ard_stack() complex call error", {


### PR DESCRIPTION
**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #251 

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
