### PR TITLE
Using `base::order()` in `ard_categorical()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cards 0.2.0.9001
 
+* Update in `ard_categorical()` to use `base::order()` instead of `dplyr::arrange()`, so the ordering of variables match the results from `base::table()` in some edge cases where sorted order was inconsistent.
+
 # cards 0.2.0
 
 ## New Features & Updates

--- a/R/ard_categorical.R
+++ b/R/ard_categorical.R
@@ -371,7 +371,7 @@ ard_categorical.data.frame <- function(data,
     ) |>
     stats::setNames(c(by, strata, variable)) %>%
     {tidyr::expand_grid(!!!.)} |> # styler: off
-    dplyr::arrange(!!!syms(rev(...ard_tab_vars...)))
+    arrange_using_order(rev(...ard_tab_vars...))
 
   # if all columns match, then replace the coerced character cols with their original type/class
   all_cols_equal <-
@@ -384,6 +384,14 @@ ard_categorical.data.frame <- function(data,
   if (isTRUE(all_cols_equal)) {
     df_table <-
       dplyr::bind_cols(df_original_types, df_table[count_column], .name_repair = "minimal")
+  }
+  # I hope this message is never triggered!
+  else {
+    cli::cli_inform(c(
+      "If you see this message, the order of the sorted variables in the tabulaton is unexpected, which could cause downstream issues.",
+      "*" = "Please post a reproducible example to {.url https://github.com/insightsengineering/cards/issues/new}, so we can address in the next release.",
+      "i" = "You can create a minimal reproducible example with {.fun reprex::reprex}."
+    ))
   }
 
   # if strata is present, remove unobserved rows
@@ -405,6 +413,11 @@ ard_categorical.data.frame <- function(data,
   }
 
   df_table
+}
+
+# like `dplyr::arrange()`, but uses base R's `order()` to keep consistency in some edge cases
+arrange_using_order <- function(data, columns) {
+  inject(data[with(data, order(!!!syms(columns))), ])
 }
 
 

--- a/tests/testthat/test-ard_categorical.R
+++ b/tests/testthat/test-ard_categorical.R
@@ -227,6 +227,17 @@ test_that("ard_categorical() with strata and by arguments", {
       denominator = ADSL |> dplyr::filter(ARM %in% "Placebo")
     )
   )
+
+  # addressing a sort edge case reported here: https://github.com/ddsjoberg/gtsummary/issues/1889
+  expect_silent(
+    ard_sort_test <-
+      iris |>
+      dplyr::mutate(
+        trt = rep_len(c("Bladder + RP LN", "Bladder + Renal Fossa"), length.out = dplyr::n())
+      ) |>
+      ard_categorical(variables = trt, by = Species)
+  )
+  expect_s3_class(ard_sort_test$group1_level[[1]], "factor")
 })
 
 test_that("ard_categorical(stat_label) argument works", {


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Update in `ard_categorical()` to use `base::order()` instead of `dplyr::arrange()`, so the ordering of variables match the results from `base::table()` in some edge cases where sorted order was inconsistent.



--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
