### PR TITLE
Fix bug introduced by returning empty ARD in `ard_complex()`

### DIFF
--- a/R/ard_complex.R
+++ b/R/ard_complex.R
@@ -74,14 +74,14 @@ ard_complex.data.frame <- function(data,
   check_not_missing(variables)
   check_not_missing(statistic)
 
+  # process inputs -------------------------------------------------------------
+  process_selectors(data, variables = {{ variables }})
+  process_formula_selectors(data[variables], statistic = statistic, allow_empty = FALSE)
+
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
     return(dplyr::tibble() |> as_card())
   }
-
-  # process inputs -------------------------------------------------------------
-  process_selectors(data, variables = {{ variables }})
-  process_formula_selectors(data[variables], statistic = statistic, allow_empty = FALSE)
 
   missing_statistics_vars <- setdiff(variables, names(statistic))
   if (!is_empty(missing_statistics_vars)) {


### PR DESCRIPTION
@ddsjoberg a bug was introduced when I added the code to return an empty ARD into `ard_complex()` since it needs to be done after `process_selectors()` has run. This PR reorders those two sections in the function to fix that. I noticed it when working on adding `cards::as_card()` to `cardx`.

Comes from #292 

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
