### PR TITLE
Added `apply_fmt_fn(replace)` argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Added the `bind_ard(.quiet)` argument to suppress messaging. (#299)
 
+* Added `apply_fmt_fn(replace)` argument. Use `replace=FALSE` to retain any previously formatted statistics in the `stat_fmt` column. (#285)
+
 # cards 0.2.1
 
 * Update in `ard_categorical()` to use `base::order()` instead of `dplyr::arrange()`, so the ordering of variables match the results from `base::table()` in some edge cases where sorted order was inconsistent.

--- a/R/apply_fmt_fn.R
+++ b/R/apply_fmt_fn.R
@@ -5,6 +5,9 @@
 #'
 #' @param x (`data.frame`)\cr
 #'   an ARD data frame of class 'card'
+#' @param replace (scalar `logical`)\cr
+#'   logical indicating whether to replace values in the `'stat_fmt'` column (if present).
+#'   Default is `FALSE`
 #'
 #' @return an ARD data frame of class 'card'
 #' @export
@@ -12,24 +15,30 @@
 #' @examples
 #' ard_continuous(ADSL, variables = "AGE") |>
 #'   apply_fmt_fn()
-apply_fmt_fn <- function(x) {
+apply_fmt_fn <- function(x, replace = FALSE) {
   set_cli_abort_call()
 
   check_class(x, cls = "card")
+  check_scalar_logical(replace)
+
+  # add stat_fmt if not already present, if replace is TRUE overwrite existing stat_fmt column
+  if (!"stat_fmt" %in% names(x) || isTRUE(replace)) {
+    x <- x |> dplyr::mutate(.after = "stat", stat_fmt = list(NULL))
+  }
 
   x |>
     dplyr::mutate(
-      .after = "stat",
       stat_fmt =
         pmap(
           list(
             .data$stat,
             .data$variable,
             .data$stat_name,
-            .data$fmt_fn
+            .data$fmt_fn,
+            .data$stat_fmt
           ),
-          function(stat, variable, stat_name, fn) {
-            if (!is.null(fn)) {
+          function(stat, variable, stat_name, fn, stat_fmt) {
+            if (!is.null(fn) && is.null(stat_fmt)) {
               tryCatch(
                 do.call(alias_as_fmt_fn(fn, variable, stat_name), args = list(stat)),
                 error = \(e) {
@@ -44,7 +53,7 @@ apply_fmt_fn <- function(x) {
                 }
               )
             } else {
-              NULL
+              stat_fmt
             }
           }
         )

--- a/R/apply_fmt_fn.R
+++ b/R/apply_fmt_fn.R
@@ -7,7 +7,7 @@
 #'   an ARD data frame of class 'card'
 #' @param replace (scalar `logical`)\cr
 #'   logical indicating whether to replace values in the `'stat_fmt'` column (if present).
-#'   Default is `FALSE`
+#'   Default is `FALSE`.
 #'
 #' @return an ARD data frame of class 'card'
 #' @export

--- a/man/apply_fmt_fn.Rd
+++ b/man/apply_fmt_fn.Rd
@@ -4,11 +4,15 @@
 \alias{apply_fmt_fn}
 \title{Apply Formatting Functions}
 \usage{
-apply_fmt_fn(x)
+apply_fmt_fn(x, replace = FALSE)
 }
 \arguments{
 \item{x}{(\code{data.frame})\cr
 an ARD data frame of class 'card'}
+
+\item{replace}{(scalar \code{logical})\cr
+logical indicating whether to replace values in the \code{'stat_fmt'} column (if present).
+Default is \code{FALSE}}
 }
 \value{
 an ARD data frame of class 'card'

--- a/man/apply_fmt_fn.Rd
+++ b/man/apply_fmt_fn.Rd
@@ -12,7 +12,7 @@ an ARD data frame of class 'card'}
 
 \item{replace}{(scalar \code{logical})\cr
 logical indicating whether to replace values in the \code{'stat_fmt'} column (if present).
-Default is \code{FALSE}}
+Default is \code{FALSE}.}
 }
 \value{
 an ARD data frame of class 'card'

--- a/tests/testthat/_snaps/apply_fmt_fn.md
+++ b/tests/testthat/_snaps/apply_fmt_fn.md
@@ -43,3 +43,31 @@
       1  NULL
       2  NULL
 
+# apply_fmt_fn(replace)
+
+    Code
+      apply_fmt_fn(ard, replace = FALSE)
+    Message
+      {cards} data frame: 3 x 10
+    Output
+        variable variable_level stat_name stat_label stat   stat_fmt
+      1   AGEGR1          65-80         n          n  144 144.000000
+      2   AGEGR1            <65         n          n   33         33
+      3   AGEGR1            >80         n          n   77         77
+    Message
+      i 4 more variables: context, fmt_fn, warning, error
+
+---
+
+    Code
+      apply_fmt_fn(ard, replace = TRUE)
+    Message
+      {cards} data frame: 3 x 10
+    Output
+        variable variable_level stat_name stat_label stat stat_fmt
+      1   AGEGR1          65-80         n          n  144      144
+      2   AGEGR1            <65         n          n   33       33
+      3   AGEGR1            >80         n          n   77       77
+    Message
+      i 4 more variables: context, fmt_fn, warning, error
+

--- a/tests/testthat/test-apply_fmt_fn.R
+++ b/tests/testthat/test-apply_fmt_fn.R
@@ -107,3 +107,21 @@ test_that("apply_fmt_fn() error messaging", {
       as.data.frame()
   )
 })
+
+test_that("apply_fmt_fn(replace)", {
+  ard <-
+    ADSL |>
+    ard_categorical(variables = AGEGR1, statistic = ~"n") |>
+    dplyr::mutate(
+      stat_fmt = ifelse(dplyr::row_number() == 1, list("144.000000"), list(NULL))
+    )
+
+  expect_snapshot(
+    apply_fmt_fn(ard, replace = FALSE)
+  )
+
+  expect_snapshot(
+    apply_fmt_fn(ard, replace = TRUE)
+  )
+
+})

--- a/tests/testthat/test-apply_fmt_fn.R
+++ b/tests/testthat/test-apply_fmt_fn.R
@@ -123,5 +123,4 @@ test_that("apply_fmt_fn(replace)", {
   expect_snapshot(
     apply_fmt_fn(ard, replace = TRUE)
   )
-
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Added `apply_fmt_fn(replace)` argument. Use `replace=FALSE` to retain any previously formatted statistics in the `stat_fmt` column. (#285)

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #285

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] Approve Pull Request
- [x] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
