### PR TITLE
Added `bind_ard(.distinct)` argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Added `apply_fmt_fn(replace)` argument. Use `replace=FALSE` to retain any previously formatted statistics in the `stat_fmt` column. (#285)
 
+* Added `bind_ard(.distinct)` argument, which can remove non-distinct rows from the ARD across grouping variables, primary variables, context, statistic name and value. (#286)
+
 # cards 0.2.1
 
 * Update in `ard_categorical()` to use `base::order()` instead of `dplyr::arrange()`, so the ordering of variables match the results from `base::table()` in some edge cases where sorted order was inconsistent.

--- a/R/bind_ard.R
+++ b/R/bind_ard.R
@@ -51,8 +51,12 @@ bind_ard <- function(..., .distinct = TRUE, .update = FALSE, .order = FALSE, .qu
     dplyr::select(data, all_ard_groups(), all_ard_variables(), any_of("context"), "stat_name", "stat")[seq(nrow(data), 1L), ] |>
     duplicated()
   if (any(not_distinct) && isTRUE(.distinct)) {
-    if (isFALSE(.quiet)) cli::cli_inform(c("i" = "{sum(not_distinct)} row{?s} with {.emph duplicated statistic values} {?has/have} been removed.",
-                                           "*" = "See {.help [cards::bind_ard(.distinct)](cards::bind_ard)} for details."))
+    if (isFALSE(.quiet)) {
+      cli::cli_inform(c(
+        "i" = "{sum(not_distinct)} row{?s} with {.emph duplicated statistic values} {?has/have} been removed.",
+        "*" = "See {.help [cards::bind_ard(.distinct)](cards::bind_ard)} for details."
+      ))
+    }
     data <-
       dplyr::filter(
         data,
@@ -67,8 +71,12 @@ bind_ard <- function(..., .distinct = TRUE, .update = FALSE, .order = FALSE, .qu
     duplicated()
 
   if (any(dupes) && isTRUE(.update)) {
-    if (isFALSE(.quiet)) cli::cli_inform(c("i" = "{sum(dupes)} row{?s} with {.emph duplicated statistic names} {?has/have} been removed.",
-                                           "*" = "See {.help [cards::bind_ard(.update)](cards::bind_ard)} for details."))
+    if (isFALSE(.quiet)) {
+      cli::cli_inform(c(
+        "i" = "{sum(dupes)} row{?s} with {.emph duplicated statistic names} {?has/have} been removed.",
+        "*" = "See {.help [cards::bind_ard(.update)](cards::bind_ard)} for details."
+      ))
+    }
     data <-
       dplyr::filter(
         data,
@@ -76,8 +84,11 @@ bind_ard <- function(..., .distinct = TRUE, .update = FALSE, .order = FALSE, .qu
         dplyr::row_number() == dplyr::n()
       )
   } else if (any(dupes) && isFALSE(.update)) {
-    cli::cli_abort(c("!" = "{sum(dupes)} row{?s} with {.emph duplicated statistic names} {?has/have} been found.",
-                     "i" = "See {.help [cards::bind_ard(.update)](cards::bind_ard)} for details."),
+    cli::cli_abort(
+      c(
+        "!" = "{sum(dupes)} row{?s} with {.emph duplicated statistic names} {?has/have} been found.",
+        "i" = "See {.help [cards::bind_ard(.update)](cards::bind_ard)} for details."
+      ),
       call = get_cli_abort_call()
     )
   }

--- a/R/bind_ard.R
+++ b/R/bind_ard.R
@@ -7,10 +7,18 @@
 #'   ARDs to combine. Each argument can either be an ARD,
 #'   or a list of ARDs. Columns are matched by name, and any missing
 #'   columns will be filled with `NA`.
+#' @param .distinct (`logical`)\cr
+#'   logical indicating whether to remove non-distinct values from the ARD.
+#'   Duplicates are checked across grouping variables, primary variables,
+#'   context (if present), the **statistic name and the statistic value**.
+#'   Default is `FALSE`. If a statistic name is repeated and `.update=TRUE`,
+#'   the more recently added statistics will be retained, and the other(s) omitted.
 #' @param .update (`logical`)\cr
-#'   logical indicating whether to update duplicate ARD statistics.
-#'   Default is `FALSE`. If a statistic type is repeated and `.update=TRUE`,
-#'   the more recently added statistics will be retained, and the others omitted.
+#'   logical indicating whether to update ARD and remove duplicated named statistics.
+#'   Duplicates are checked across grouping variables, primary variables, and the
+#'   **statistic name**.
+#'   Default is `FALSE`. If a statistic name is repeated and `.update=TRUE`,
+#'   the more recently added statistics will be retained, and the other(s) omitted.
 #' @param .order (`logical`)\cr
 #'   logical indicating whether to order the rows of the stacked ARDs, allowing
 #'   statistics that share common group and variable values to appear in
@@ -26,10 +34,11 @@
 #' ard <- ard_categorical(ADSL, by = "ARM", variables = "AGEGR1")
 #'
 #' bind_ard(ard, ard, .update = TRUE)
-bind_ard <- function(..., .update = FALSE, .order = FALSE, .quiet = FALSE) {
+bind_ard <- function(..., .distinct = TRUE, .update = FALSE, .order = FALSE, .quiet = FALSE) {
   set_cli_abort_call()
 
   # check inputs ---------------------------------------------------------------
+  check_scalar_logical(.distinct)
   check_scalar_logical(.update)
   check_scalar_logical(.order)
   check_scalar_logical(.quiet)
@@ -37,13 +46,29 @@ bind_ard <- function(..., .update = FALSE, .order = FALSE, .quiet = FALSE) {
   # stack ARDs -----------------------------------------------------------------
   data <- dplyr::bind_rows(...)
 
-  # check for duplicates -------------------------------------------------------
+  # check for non-distinct statistics ------------------------------------------
+  not_distinct <-
+    dplyr::select(data, all_ard_groups(), all_ard_variables(), any_of("context"), "stat_name", "stat")[seq(nrow(data), 1L), ] |>
+    duplicated()
+  if (any(not_distinct) && isTRUE(.distinct)) {
+    if (isFALSE(.quiet)) cli::cli_inform(c("i" = "{sum(not_distinct)} row{?s} with {.emph duplicated statistic values} {?has/have} been removed.",
+                                           "*" = "See {.help [cards::bind_ard(.distinct)](cards::bind_ard)} for details."))
+    data <-
+      dplyr::filter(
+        data,
+        .by = c(all_ard_groups(), all_ard_variables(), "stat_name"),
+        dplyr::row_number() == dplyr::n()
+      )
+  }
+
+  # check for duplicate stat_name ----------------------------------------------
   dupes <-
     dplyr::select(data, all_ard_groups(), all_ard_variables(), "stat_name")[seq(nrow(data), 1L), ] |>
     duplicated()
 
   if (any(dupes) && isTRUE(.update)) {
-    if (isFALSE(.quiet)) cli::cli_inform(c("i" = "{sum(dupes)} duplicate observation{?/s} removed."))
+    if (isFALSE(.quiet)) cli::cli_inform(c("i" = "{sum(dupes)} row{?s} with {.emph duplicated statistic names} {?has/have} been removed.",
+                                           "*" = "See {.help [cards::bind_ard(.update)](cards::bind_ard)} for details."))
     data <-
       dplyr::filter(
         data,
@@ -51,7 +76,8 @@ bind_ard <- function(..., .update = FALSE, .order = FALSE, .quiet = FALSE) {
         dplyr::row_number() == dplyr::n()
       )
   } else if (any(dupes) && isFALSE(.update)) {
-    cli::cli_abort(c("!" = "{sum(dupes)} duplicate observation{?/s} found."),
+    cli::cli_abort(c("!" = "{sum(dupes)} row{?s} with {.emph duplicated statistic names} {?has/have} been found.",
+                     "i" = "See {.help [cards::bind_ard(.update)](cards::bind_ard)} for details."),
       call = get_cli_abort_call()
     )
   }

--- a/R/bind_ard.R
+++ b/R/bind_ard.R
@@ -11,7 +11,7 @@
 #'   logical indicating whether to remove non-distinct values from the ARD.
 #'   Duplicates are checked across grouping variables, primary variables,
 #'   context (if present), the **statistic name and the statistic value**.
-#'   Default is `FALSE`. If a statistic name is repeated and `.update=TRUE`,
+#'   Default is `FALSE`. If a statistic name and value is repeated and `.distinct=TRUE`,
 #'   the more recently added statistics will be retained, and the other(s) omitted.
 #' @param .update (`logical`)\cr
 #'   logical indicating whether to update ARD and remove duplicated named statistics.

--- a/man/bind_ard.Rd
+++ b/man/bind_ard.Rd
@@ -22,7 +22,7 @@ columns will be filled with \code{NA}.}
 logical indicating whether to remove non-distinct values from the ARD.
 Duplicates are checked across grouping variables, primary variables,
 context (if present), the \strong{statistic name and the statistic value}.
-Default is \code{FALSE}. If a statistic name is repeated and \code{.update=TRUE},
+Default is \code{FALSE}. If a statistic name and value is repeated and \code{.distinct=TRUE},
 the more recently added statistics will be retained, and the other(s) omitted.}
 
 \item{.update}{(\code{logical})\cr

--- a/man/bind_ard.Rd
+++ b/man/bind_ard.Rd
@@ -4,7 +4,13 @@
 \alias{bind_ard}
 \title{Bind ARDs}
 \usage{
-bind_ard(..., .update = FALSE, .order = FALSE, .quiet = FALSE)
+bind_ard(
+  ...,
+  .distinct = TRUE,
+  .update = FALSE,
+  .order = FALSE,
+  .quiet = FALSE
+)
 }
 \arguments{
 \item{...}{(\code{\link[rlang:dyn-dots]{dynamic-dots}})\cr
@@ -12,10 +18,19 @@ ARDs to combine. Each argument can either be an ARD,
 or a list of ARDs. Columns are matched by name, and any missing
 columns will be filled with \code{NA}.}
 
+\item{.distinct}{(\code{logical})\cr
+logical indicating whether to remove non-distinct values from the ARD.
+Duplicates are checked across grouping variables, primary variables,
+context (if present), the \strong{statistic name and the statistic value}.
+Default is \code{FALSE}. If a statistic name is repeated and \code{.update=TRUE},
+the more recently added statistics will be retained, and the other(s) omitted.}
+
 \item{.update}{(\code{logical})\cr
-logical indicating whether to update duplicate ARD statistics.
-Default is \code{FALSE}. If a statistic type is repeated and \code{.update=TRUE},
-the more recently added statistics will be retained, and the others omitted.}
+logical indicating whether to update ARD and remove duplicated named statistics.
+Duplicates are checked across grouping variables, primary variables, and the
+\strong{statistic name}.
+Default is \code{FALSE}. If a statistic name is repeated and \code{.update=TRUE},
+the more recently added statistics will be retained, and the other(s) omitted.}
 
 \item{.order}{(\code{logical})\cr
 logical indicating whether to order the rows of the stacked ARDs, allowing

--- a/tests/testthat/_snaps/bind_ard.md
+++ b/tests/testthat/_snaps/bind_ard.md
@@ -9,10 +9,11 @@
 ---
 
     Code
-      bind_ard(ard, ard, .update = FALSE)
+      bind_ard(ard, ard, .distinct = FALSE, .update = FALSE)
     Condition
       Error in `bind_ard()`:
-      ! 27 duplicate observations found.
+      ! 27 rows with duplicated statistic names have been found.
+      i See cards::bind_ard(.update) (`?cards::bind_ard()`) for details.
 
 # bind_ard() .order argument works
 
@@ -107,4 +108,27 @@
       16        44
       17        84
       18        34
+
+# bind_ard(.distinct)
+
+    Code
+      ard_continuous(ADSL, variables = AGE) %>% {
+        bind_ard(., ., .update = FALSE)
+      }
+    Message
+      i 8 rows with duplicated statistic values have been removed.
+      * See cards::bind_ard(.distinct) (`?cards::bind_ard()`) for details.
+      {cards} data frame: 8 x 8
+    Output
+        variable   context stat_name stat_label   stat fmt_fn
+      1      AGE continuo…         N          N    254      0
+      2      AGE continuo…      mean       Mean 75.087      1
+      3      AGE continuo…        sd         SD  8.246      1
+      4      AGE continuo…    median     Median     77      1
+      5      AGE continuo…       p25         Q1     70      1
+      6      AGE continuo…       p75         Q3     81      1
+      7      AGE continuo…       min        Min     51      1
+      8      AGE continuo…       max        Max     89      1
+    Message
+      i 2 more variables: warning, error
 

--- a/tests/testthat/test-bind_ard.R
+++ b/tests/testthat/test-bind_ard.R
@@ -17,7 +17,7 @@ test_that("ARD helpers messaging", {
   )
 
   expect_snapshot(
-    bind_ard(ard, ard, .update = FALSE),
+    bind_ard(ard, ard, .distinct = FALSE, .update = FALSE),
     error = TRUE
   )
 })
@@ -51,5 +51,12 @@ test_that("bind_ard(.quiet)", {
   expect_silent(
     ard_continuous(ADSL, variables = AGE) %>%
       {bind_ard(., ., .update = TRUE, .quiet = TRUE)} # styler: off
+  )
+})
+
+test_that("bind_ard(.distinct)", {
+  expect_snapshot(
+    ard_continuous(ADSL, variables = AGE) %>%
+      {bind_ard(., ., .update = FALSE)} # styler: off
   )
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Added `bind_ard(.distinct)` argument, which can remove non-distinct rows from the ARD across grouping variables, primary variables, context, statistic name and value. (#286)

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #286 

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
