### PR TITLE
Bug fix in `print_ard_conditions()` when message had curly brace pairs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * Added `bind_ard(.distinct)` argument, which can remove non-distinct rows from the ARD across grouping variables, primary variables, context, statistic name and value. (#286)
 
+* Bug fix in `print_ard_conditions()` and we can now print condition messages that contain curly brace pairs. (#309)
+
 # cards 0.2.1
 
 * Update in `ard_categorical()` to use `base::order()` instead of `dplyr::arrange()`, so the ordering of variables match the results from `base::table()` in some edge cases where sorted order was inconsistent.

--- a/R/print_ard_conditions.R
+++ b/R/print_ard_conditions.R
@@ -108,7 +108,6 @@ print_ard_conditions <- function(x) {
           "For variable {ard_msg$cli_variable_msg[[i]]} ",
           "{switch(!is.null(ard_msg$cli_group_msg[[i]]), paste0('(', ard_msg$cli_group_msg[[i]], ')')) %||% ''} ",
           "and {{.val {{ard_msg$all_stat_names[[i]]}}}} statistic{{?s}}"
-
         ),
         "{ard_msg$cond_msg[[i]]}",
         sep = ": "

--- a/R/print_ard_conditions.R
+++ b/R/print_ard_conditions.R
@@ -102,18 +102,22 @@ print_ard_conditions <- function(x) {
   )
 
   for (i in seq_len(nrow(ard_msg))) {
-    cli::cli_inform(c(
-      glue::glue(
-        "For variable {ard_msg$cli_variable_msg[[i]]} ",
-        "{switch(!is.null(ard_msg$cli_group_msg[[i]]), paste0('(', ard_msg$cli_group_msg[[i]], ')')) %||% ''} ",
-        "and {{.val {{ard_msg$all_stat_names[[i]]}}}} statistic{{?s}}: ",
-        "{ard_msg$cond_msg[[i]]}"
+    cli::cli_inform(
+      paste(
+        glue::glue(
+          "For variable {ard_msg$cli_variable_msg[[i]]} ",
+          "{switch(!is.null(ard_msg$cli_group_msg[[i]]), paste0('(', ard_msg$cli_group_msg[[i]], ')')) %||% ''} ",
+          "and {{.val {{ard_msg$all_stat_names[[i]]}}}} statistic{{?s}}"
+
+        ),
+        "{ard_msg$cond_msg[[i]]}",
+        sep = ": "
       ) |>
         stats::setNames(switch(msg_type,
           "warning" = "!",
           "error" = "x"
         ))
-    ))
+    )
   }
 
   invisible()

--- a/tests/testthat/_snaps/print_ard_conditions.md
+++ b/tests/testthat/_snaps/print_ard_conditions.md
@@ -79,3 +79,13 @@
       ! For variable `continuous_var` (`by_var = "cohort_1"`) and "min" statistic: no non-missing arguments to min; returning Inf
       ! For variable `continuous_var` (`by_var = "cohort_1"`) and "max" statistic: no non-missing arguments to max; returning -Inf
 
+# print_ard_conditions() works when curly brackets appear in condition message
+
+    Code
+      print_ard_conditions(ard)
+    Message
+      The following errors were returned during `print_ard_conditions()`:
+      x For variable `AGE` and "mean" statistic: error with {curly} brackets
+      The following warnings were returned during `print_ard_conditions()`:
+      ! For variable `AGE` and "mean" statistic: warning with {curly} brackets
+

--- a/tests/testthat/test-print_ard_conditions.R
+++ b/tests/testthat/test-print_ard_conditions.R
@@ -102,3 +102,17 @@ test_that("print_ard_conditions() no error when factors are present", {
     print_ard_conditions(ard)
   )
 })
+
+# See issue #309
+test_that("print_ard_conditions() works when curly brackets appear in condition message", {
+  # add a warning message that has curly brackets in it
+  ard <- ard_continuous(ADSL, variables = AGE, statistic = ~ continuous_summary_fns("mean")) |>
+    dplyr::mutate(
+      warning = list("warning with {curly} brackets"),
+      error = list("error with {curly} brackets")
+    )
+
+  expect_snapshot(
+    print_ard_conditions(ard)
+  )
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Bug fix in `print_ard_conditions()` and we can now print condition messages that contain curly brace pairs. (#309)

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #309

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
