### PR TITLE
Removing NA `ard_stack(.by)` values from calculations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cards 0.2.2.9002
 
+* Any rows with `NA` or `NaN` values in the `.by` columns specified in `ard_stack()` are now removed from all calculations. (#320)
+
 # cards 0.2.2
 
 ## New Features & Updates

--- a/R/ard_stack.R
+++ b/R/ard_stack.R
@@ -88,8 +88,8 @@ ard_stack <- function(data,
   df_na_by <- is.na(data[.by]) | apply(data[.by], MARGIN = 2, is.nan)
   if (!is_empty(.by) && any(df_na_by)) {
     rows_with_na <- apply(df_na_by, MARGIN = 1, any)
-    cli::cli_inform("*" = "Removing {.val {sum(rows_with_na)}} row{?s} with
-                           {.val {NA}} or {.val {NaN}} values in {.val {eval(.by)}} column{?s}.")
+    cli::cli_inform(c("*" = "Removing {.val {sum(rows_with_na)}} row{?s} with
+                            {.val {NA}} or {.val {NaN}} values in {.val {eval(.by)}} column{?s}."))
     data <- data[!rows_with_na, ]
   }
 

--- a/man/ard_stack.Rd
+++ b/man/ard_stack.Rd
@@ -23,7 +23,8 @@ a data frame}
 Series of ARD function calls to be run and stacked}
 
 \item{.by}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
-columns to tabulate by in the series of ARD function calls}
+columns to tabulate by in the series of ARD function calls.
+Any rows with \code{NA} or \code{NaN} values are removed from all calculations.}
 
 \item{.overall}{(\code{logical})\cr logical indicating whether overall statistics
 should be calculated (i.e. re-run all \verb{ard_*()} calls with \code{by=NULL}).

--- a/tests/testthat/test-ard_stack.R
+++ b/tests/testthat/test-ard_stack.R
@@ -297,7 +297,7 @@ test_that("ard_stack(.by) messaging", {
   expect_snapshot(
     mtcars2 |>
       ard_stack(
-        ard_continuous(variables = "mpg", statistic = ~continuous_summary_fns("N")),
+        ard_continuous(variables = "mpg", statistic = ~ continuous_summary_fns("N")),
         .by = c(am, vs),
         .total_n = TRUE,
         .overall = TRUE
@@ -311,7 +311,7 @@ test_that("ard_stack(.by) messaging", {
   expect_snapshot(
     mtcars3 |>
       ard_stack(
-        ard_continuous(variables = "mpg", statistic = ~continuous_summary_fns("N")),
+        ard_continuous(variables = "mpg", statistic = ~ continuous_summary_fns("N")),
         .by = c(am, vs),
         .total_n = TRUE,
         .overall = TRUE

--- a/tests/testthat/test-ard_stack.R
+++ b/tests/testthat/test-ard_stack.R
@@ -289,3 +289,33 @@ test_that("ard_stack() follows ard structure", {
       check_ard_structure(method = FALSE)
   )
 })
+
+test_that("ard_stack(.by) messaging", {
+  mtcars2 <- mtcars
+  mtcars2$am[1] <- NA
+  mtcars2$vs[1] <- NA
+  expect_snapshot(
+    mtcars2 |>
+      ard_stack(
+        ard_continuous(variables = "mpg", statistic = ~continuous_summary_fns("N")),
+        .by = c(am, vs),
+        .total_n = TRUE,
+        .overall = TRUE
+      ) |>
+      dplyr::filter(stat_name %in% "N")
+  )
+
+  mtcars3 <- mtcars
+  mtcars3$am[1] <- NA
+  mtcars3$vs[2] <- NaN
+  expect_snapshot(
+    mtcars3 |>
+      ard_stack(
+        ard_continuous(variables = "mpg", statistic = ~continuous_summary_fns("N")),
+        .by = c(am, vs),
+        .total_n = TRUE,
+        .overall = TRUE
+      ) |>
+      dplyr::filter(stat_name %in% "N")
+  )
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Any rows with `NA` or `NaN` values in the `.by` columns specified in `ard_stack()` are now removed from all calculations. (#320)

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #320 

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
