### PR TITLE
Adding `rename_ard_columns(unlist)` argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Added functions `update_ard_fmt_fn()` and `update_ard_stat_label()` to update an ARD's formatting function and statistic label, respectively. (#253)
 
+* Added `rename_ard_columns(unlist)` argument, which unlists specified columns in the ARD data frame. (#313)
+
 # cards 0.2.2
 
 ## New Features & Updates

--- a/R/shift_ard_columns.R
+++ b/R/shift_ard_columns.R
@@ -38,18 +38,22 @@ rename_ard_columns <- function(x, columns = c(all_ard_groups(), all_ard_variable
       unlisted <-
         eval_capture_conditions(unlist(x[[unlist_var]])) |>
         captured_condition_as_error(
-          message = c("!" = "The following error occured while unlisting column {.val {unlist_var}}.",
-                      "x" = "{condition}")
+          message = c(
+            "!" = "The following error occured while unlisting column {.val {unlist_var}}.",
+            "x" = "{condition}"
+          )
         )
       if (is.list(unlisted)) {
         cli::cli_inform(c("Unable to unlist column {.val {unlist_var}}.",
-                          "i" = "This often occurs when a list column contains elements that cannot coerced to a common type."))
+          "i" = "This often occurs when a list column contains elements that cannot coerced to a common type."
+        ))
       }
 
       if (length(unlisted) != length(x[[unlist_var]])) {
         cli::cli_abort(
           c("Cannot unlist column {.val {unlist_var}}. The unlisted result is not the same length as the original.",
-            "i" = "This often occurs when the column contains {.code NULL} values."),
+            "i" = "This often occurs when the column contains {.code NULL} values."
+          ),
           call = get_cli_abort_call()
         )
       }

--- a/R/shift_ard_columns.R
+++ b/R/shift_ard_columns.R
@@ -8,34 +8,67 @@
 #'   a data frame
 #' @param columns ([`tidy-select`][dplyr::dplyr_tidy_select])\cr
 #'   Name of columns to coalesce together and rename.
+#' @param unlist ([`tidy-select`][dplyr::dplyr_tidy_select])\cr
+#'   Columns to unlist. Often useful when performing visual inspection
+#'   of the results where the list-columns are more difficult to work with.
 #'
 #' @return data frame
 #' @export
 #'
 #' @examples
-#' data <- data.frame(group1 = "A", group1_level = "B", variable = "C", variable_level = "D")
-#'
-#' rename_ard_columns(data)
-#' rename_ard_columns(data, columns = c("group1", "group1_level"))
-rename_ard_columns <- function(x, columns = c(all_ard_groups(), all_ard_variables())) {
+#' ADSL |>
+#'   ard_categorical(by = ARM, variables = AGEGR1) |>
+#'   apply_fmt_fn() |>
+#'   rename_ard_columns(unlist = c(stat, stat_fmt))
+rename_ard_columns <- function(x, columns = c(all_ard_groups(), all_ard_variables()), unlist = NULL) {
+  set_cli_abort_call()
   # check inputs ---------------------------------------------------------------
   check_not_missing(col)
 
   # process arguments ----------------------------------------------------------
-  process_selectors(x, columns = {{ columns }})
+  process_selectors(x, columns = {{ columns }}, unlist = {{ unlist }})
 
-  if (length(columns) == 0) {
+  if (is_empty(columns) && is_empty(unlist)) {
     return(x)
   }
 
-  # determine pairs of variables and levels ------------------------------------
-  column_pairs <- .pair_columns(x, columns)
+  # unlist columns -------------------------------------------------------------
+  if (!is_empty(unlist)) {
+    for (unlist_var in unlist) {
+      unlisted <-
+        eval_capture_conditions(unlist(x[[unlist_var]])) |>
+        captured_condition_as_error(
+          message = c("!" = "The following error occured while unlisting column {.val {unlist_var}}.",
+                      "x" = "{condition}")
+        )
+      if (is.list(unlisted)) {
+        cli::cli_inform(c("Unable to unlist column {.val {unlist_var}}.",
+                          "i" = "This often occurs when a list column contains elements that cannot coerced to a common type."))
+      }
 
-  # Sequentially coalesce/rename -----------------------------------------------
-  for (col_pair in column_pairs) {
-    x <- .shift_column_pair(x, col_pair)
+      if (length(unlisted) != length(x[[unlist_var]])) {
+        cli::cli_abort(
+          c("Cannot unlist column {.val {unlist_var}}. The unlisted result is not the same length as the original.",
+            "i" = "This often occurs when the column contains {.code NULL} values."),
+          call = get_cli_abort_call()
+        )
+      }
+      x[[unlist_var]] <- unlisted
+    }
   }
 
+  # rename columns -------------------------------------------------------------
+  if (!is_empty(columns)) {
+    # determine pairs of variables and levels
+    column_pairs <- .pair_columns(x, columns)
+
+    # Sequentially coalesce/rename
+    for (col_pair in column_pairs) {
+      x <- .shift_column_pair(x, col_pair)
+    }
+  }
+
+  # return final ARD -----------------------------------------------------------
   x
 }
 

--- a/man/rename_ard_columns.Rd
+++ b/man/rename_ard_columns.Rd
@@ -4,7 +4,11 @@
 \alias{rename_ard_columns}
 \title{Rename ARD Columns}
 \usage{
-rename_ard_columns(x, columns = c(all_ard_groups(), all_ard_variables()))
+rename_ard_columns(
+  x,
+  columns = c(all_ard_groups(), all_ard_variables()),
+  unlist = NULL
+)
 }
 \arguments{
 \item{x}{(\code{data.frame})\cr
@@ -12,6 +16,10 @@ a data frame}
 
 \item{columns}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
 Name of columns to coalesce together and rename.}
+
+\item{unlist}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
+Columns to unlist. Often useful when performing visual inspection
+of the results where the list-columns are more difficult to work with.}
 }
 \value{
 data frame
@@ -22,8 +30,8 @@ single column. The \code{group_level} or \code{variable_level} column is renamed
 the \code{group} or \code{variable} column, respectively.
 }
 \examples{
-data <- data.frame(group1 = "A", group1_level = "B", variable = "C", variable_level = "D")
-
-rename_ard_columns(data)
-rename_ard_columns(data, columns = c("group1", "group1_level"))
+ADSL |>
+  ard_categorical(by = ARM, variables = AGEGR1) |>
+  apply_fmt_fn() |>
+  rename_ard_columns(unlist = c(stat, stat_fmt))
 }

--- a/tests/testthat/_snaps/rename_ard_columns.md
+++ b/tests/testthat/_snaps/rename_ard_columns.md
@@ -1,0 +1,47 @@
+# rename_ard_columns(unlist)
+
+    Code
+      rename_ard_columns(apply_fmt_fn(ard_categorical(ADSL, by = ARM, variables = AGEGR1)),
+      unlist = c(stat, stat_fmt))
+    Output
+      # A tibble: 27 x 10
+         ARM        AGEGR1 context stat_name stat_label   stat stat_fmt fmt_fn warning
+         <chr>      <chr>  <chr>   <chr>     <chr>       <dbl> <chr>    <list> <list> 
+       1 Placebo    65-80  catego~ n         n          42     42       <int>  <NULL> 
+       2 Placebo    65-80  catego~ N         N          86     86       <int>  <NULL> 
+       3 Placebo    65-80  catego~ p         %           0.488 48.8     <fn>   <NULL> 
+       4 Xanomelin~ 65-80  catego~ n         n          55     55       <int>  <NULL> 
+       5 Xanomelin~ 65-80  catego~ N         N          84     84       <int>  <NULL> 
+       6 Xanomelin~ 65-80  catego~ p         %           0.655 65.5     <fn>   <NULL> 
+       7 Xanomelin~ 65-80  catego~ n         n          47     47       <int>  <NULL> 
+       8 Xanomelin~ 65-80  catego~ N         N          84     84       <int>  <NULL> 
+       9 Xanomelin~ 65-80  catego~ p         %           0.560 56.0     <fn>   <NULL> 
+      10 Placebo    <65    catego~ n         n          14     14       <int>  <NULL> 
+      # i 17 more rows
+      # i 1 more variable: error <list>
+
+# rename_ard_columns(unlist) messaging
+
+    Code
+      head(rename_ard_columns(dplyr::mutate(ard_categorical(ADSL, by = ARM,
+        variables = AGEGR1), stat = ifelse(dplyr::row_number() == 1L, list(median),
+      stat)), unlist = stat), 1L)
+    Message
+      Unable to unlist column "stat".
+      i This often occurs when a list column contains elements that cannot coerced to a common type.
+    Output
+      # A tibble: 1 x 9
+        ARM     AGEGR1 context     stat_name stat_label stat   fmt_fn warning error 
+        <chr>   <chr>  <chr>       <chr>     <chr>      <list> <list> <list>  <list>
+      1 Placebo 65-80  categorical n         n          <fn>   <int>  <NULL>  <NULL>
+
+---
+
+    Code
+      rename_ard_columns(dplyr::mutate(ard_categorical(ADSL, by = ARM, variables = AGEGR1),
+      stat = ifelse(dplyr::row_number() == 1L, list(NULL), stat)), unlist = stat)
+    Condition
+      Error in `rename_ard_columns()`:
+      ! Cannot unlist column "stat". The unlisted result is not the same length as the original.
+      i This often occurs when the column contains `NULL` values.
+

--- a/tests/testthat/test-rename_ard_columns.R
+++ b/tests/testthat/test-rename_ard_columns.R
@@ -1,0 +1,37 @@
+test_that("rename_ard_columns(columns)", {
+  expect_equal(
+    ADSL |>
+      ard_categorical(by = ARM, variables = AGEGR1) |>
+      rename_ard_columns() %>%
+      `[`(1:2) |>
+      names(),
+    c("ARM", "AGEGR1")
+  )
+})
+
+test_that("rename_ard_columns(unlist)", {
+  expect_snapshot(
+    ADSL |>
+      ard_categorical(by = ARM, variables = AGEGR1) |>
+      apply_fmt_fn() |>
+      rename_ard_columns(unlist = c(stat, stat_fmt))
+  )
+})
+
+test_that("rename_ard_columns(unlist) messaging", {
+  expect_snapshot(
+    ADSL |>
+      ard_categorical(by = ARM, variables = AGEGR1) |>
+      dplyr::mutate(stat = ifelse(dplyr::row_number() == 1L, list(median), stat)) |>
+      rename_ard_columns(unlist = stat) |>
+      head(1L)
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    ADSL |>
+      ard_categorical(by = ARM, variables = AGEGR1) |>
+      dplyr::mutate(stat = ifelse(dplyr::row_number() == 1L, list(NULL), stat)) |>
+      rename_ard_columns(unlist = stat)
+  )
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Added `rename_ard_columns(unlist)` argument, which unlists specified columns in the ARD data frame. (#313)

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #313
closes #312

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
