### PR TITLE
Improved msg in `print_ard_conditions()` when the calling function is namedspaced

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * No longer exporting functions `check_pkg_installed()`, `is_pkg_installed()`, `get_min_version_required()`, `get_pkg_dependencies()`. These functions are now internal-only. (#330)
 
+* Improved messaging in `print_ard_conditions()` when the calling function is namespaced. (#348)
+
 # cards 0.3.0
 
 ## New Features & Updates

--- a/R/print_ard_conditions.R
+++ b/R/print_ard_conditions.R
@@ -98,7 +98,7 @@ print_ard_conditions <- function(x) {
   # and finally, print the messages
   cli::cli_inform(
     "The following {cli_color_fun(paste0(msg_type, 's'))} were returned during
-       {.fun {error_call(get_cli_abort_call()) |> as.list() |> getElement(1L)}}:"
+       {.fun {error_call(get_cli_abort_call()) |> rlang::call_name()}}:"
   )
 
   for (i in seq_len(nrow(ard_msg))) {


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Improved messaging in `print_ard_conditions()` when the calling function is namespaced. (#348)

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #348

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
