### PR TITLE
Update  awkward by/strata phrasing

### DIFF
--- a/R/ard_categorical.R
+++ b/R/ard_categorical.R
@@ -5,7 +5,7 @@
 #' @param data (`data.frame`)\cr
 #'   a data frame
 #' @param by,strata ([`tidy-select`][dplyr::dplyr_tidy_select])\cr
-#'   columns to tabulate by/stratify by for tabulation.
+#'   columns to use for grouping or stratifying the table output.
 #'   Arguments are similar, but with an important distinction:
 #'
 #'   `by`: results are tabulated by **all combinations** of the columns specified,

--- a/R/print.R
+++ b/R/print.R
@@ -38,9 +38,13 @@ print.card <- function(x, n = NULL, columns = c("auto", "all"), n_col = 6L, ...)
   # remove columns -------------------------------------------------------------
   if (arg_match(columns) %in% "auto") {
     x_print <-
-      dplyr::select(x_print, all_ard_groups(), all_ard_variables(),
-                    any_of(c("context", "stat_name", "stat_label", "stat", "stat_fmt",
-                             "fmt_fn", "warning", "error")))
+      dplyr::select(
+        x_print, all_ard_groups(), all_ard_variables(),
+        any_of(c(
+          "context", "stat_name", "stat_label", "stat", "stat_fmt",
+          "fmt_fn", "warning", "error"
+        ))
+      )
 
     # remove warning and error columns if nothing to report
     if (ncol(x_print) > n_col && "warning" %in% names(x_print) && every(x_print[["warning"]], is.null)) {

--- a/man/ard_categorical.Rd
+++ b/man/ard_categorical.Rd
@@ -29,7 +29,7 @@ a data frame}
 columns to include in summaries. Default is \code{everything()}.}
 
 \item{by, strata}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
-columns to tabulate by/stratify by for tabulation.
+columns to use for grouping or stratifying the table output.
 Arguments are similar, but with an important distinction:
 
 \code{by}: results are tabulated by \strong{all combinations} of the columns specified,

--- a/man/ard_dichotomous.Rd
+++ b/man/ard_dichotomous.Rd
@@ -30,7 +30,7 @@ a data frame}
 columns to include in summaries. Default is \code{everything()}.}
 
 \item{by, strata}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
-columns to tabulate by/stratify by for tabulation.
+columns to use for grouping or stratifying the table output.
 Arguments are similar, but with an important distinction:
 
 \code{by}: results are tabulated by \strong{all combinations} of the columns specified,

--- a/man/dot-calculate_tabulation_statistics.Rd
+++ b/man/dot-calculate_tabulation_statistics.Rd
@@ -21,7 +21,7 @@ a data frame}
 columns to include in summaries. Default is \code{everything()}.}
 
 \item{by, strata}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
-columns to tabulate by/stratify by for tabulation.
+columns to use for grouping or stratifying the table output.
 Arguments are similar, but with an important distinction:
 
 \code{by}: results are tabulated by \strong{all combinations} of the columns specified,

--- a/man/dot-process_denominator.Rd
+++ b/man/dot-process_denominator.Rd
@@ -18,7 +18,7 @@ Specify this \emph{optional} argument to change the denominator,
 e.g. the \code{"N"} statistic. Default is \code{NULL}. See below for details.}
 
 \item{by, strata}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
-columns to tabulate by/stratify by for tabulation.
+columns to use for grouping or stratifying the table output.
 Arguments are similar, but with an important distinction:
 
 \code{by}: results are tabulated by \strong{all combinations} of the columns specified,

--- a/tests/testthat/test-ard_hierarchical.R
+++ b/tests/testthat/test-ard_hierarchical.R
@@ -350,10 +350,12 @@ test_that("ard_hierarchical_count() provides correct results with 10+ groups", {
   expect_equal(
     dplyr::select(ard, all_ard_groups(), all_ard_variables()) |>
       names(),
-    c('group1', 'group1_level', 'group2', 'group2_level', 'group3', 'group3_level',
-      'group4', 'group4_level', 'group5', 'group5_level', 'group6', 'group6_level',
-      'group7', 'group7_level', 'group8', 'group8_level', 'group9', 'group9_level',
-      'variable', 'variable_level')
+    c(
+      "group1", "group1_level", "group2", "group2_level", "group3", "group3_level",
+      "group4", "group4_level", "group5", "group5_level", "group6", "group6_level",
+      "group7", "group7_level", "group8", "group8_level", "group9", "group9_level",
+      "variable", "variable_level"
+    )
   )
 
   expect_equal(ard[["variable"]][[1]], "x10")

--- a/tests/testthat/test-tidy_ard_column_order.R
+++ b/tests/testthat/test-tidy_ard_column_order.R
@@ -24,9 +24,11 @@ test_that("tidy_ard_column_order() works", {
       ) |>
       dplyr::select(all_ard_groups(), all_ard_variables()) |>
       names(),
-    c('group1', 'group1_level', 'group2', 'group2_level', 'group3', 'group3_level',
-      'group4', 'group4_level', 'group5', 'group5_level', 'group6', 'group6_level',
-      'group7', 'group7_level', 'group8', 'group8_level', 'group9', 'group9_level',
-      'group10', 'group10_level', 'variable', 'variable_level')
+    c(
+      "group1", "group1_level", "group2", "group2_level", "group3", "group3_level",
+      "group4", "group4_level", "group5", "group5_level", "group6", "group6_level",
+      "group7", "group7_level", "group8", "group8_level", "group9", "group9_level",
+      "group10", "group10_level", "variable", "variable_level"
+    )
   )
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**

* Update phrasing for `by` and `strata` arguments (#325 )

Provide more detail here as needed.

Went with the phrasing I suggested in #325, let me know what you think - happy to brainstorm a little more if it's still not what we're after

closes #325 


--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
