### PR TITLE
Adde `print_ard_conditions(condition_type)` argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Added functions `rename_ard_groups_shift()` and `rename_ard_groups_reverse()` for renaming the grouping variables in the ARD. (#344)
 
+* Added the `print_ard_conditions(condition_type)` argument, which allows users to select to return conditions as messages (the default), or have warnings returned as warnings and errors as errors. (#386)
+
 # cards 0.4.0
 
 ## New Features and Functions

--- a/man/dot-cli_condition_messaging.Rd
+++ b/man/dot-cli_condition_messaging.Rd
@@ -4,7 +4,7 @@
 \alias{.cli_condition_messaging}
 \title{Print Condition Messages Saved in an ARD}
 \usage{
-.cli_condition_messaging(x, msg_type)
+.cli_condition_messaging(x, msg_type, condition_type)
 }
 \arguments{
 \item{x}{(\code{data.frame})\cr

--- a/man/print_ard_conditions.Rd
+++ b/man/print_ard_conditions.Rd
@@ -4,11 +4,16 @@
 \alias{print_ard_conditions}
 \title{Print ARD Condition Messages}
 \usage{
-print_ard_conditions(x)
+print_ard_conditions(x, condition_type = c("inform", "identity"))
 }
 \arguments{
 \item{x}{(\code{data.frame})\cr
 an ARD data frame of class 'card'}
+
+\item{condition_type}{(\code{string})\cr
+indicates how warnings and errors are returned.
+Default is \code{"inform"} where all are returned as messages.
+When \code{"identity"}, errors are returned as errors and warnings as warnings.}
 }
 \value{
 returns invisible if check is successful, throws all condition messages if not.

--- a/tests/testthat/_snaps/print_ard_conditions.md
+++ b/tests/testthat/_snaps/print_ard_conditions.md
@@ -64,6 +64,35 @@
       The following errors were returned during `tbl_summary()`:
       x For variable `AGE` and "err_fn" statistic: 'tis an error
 
+# print_ard_conditions(condition_type)
+
+    Code
+      print_ard_conditions(ard_continuous(ADSL, variables = AGE, statistic = ~ list(
+        mean_warning = function(x) {
+          warning("warn1")
+          warning("warn2")
+          mean(x)
+        })), condition_type = "identity")
+    Message
+      The following warnings were returned during `print_ard_conditions()`:
+    Condition
+      Warning:
+      ! For variable `AGE` and "mean_warning" statistic: warn1
+      Warning:
+      ! For variable `AGE` and "mean_warning" statistic: warn2
+
+---
+
+    Code
+      print_ard_conditions(ard_continuous(ADSL, variables = AGE, statistic = ~ list(
+        mean = function(x) mean(x), err_fn = function(x) stop("'tis an error"))),
+      condition_type = "identity")
+    Message
+      The following errors were returned during `print_ard_conditions()`:
+    Condition
+      Error in `print_ard_conditions()`:
+      x For variable `AGE` and "err_fn" statistic: 'tis an error
+
 # print_ard_conditions() no error when 'error'/'warning' columns not present
 
     Code

--- a/tests/testthat/test-print_ard_conditions.R
+++ b/tests/testthat/test-print_ard_conditions.R
@@ -76,8 +76,7 @@ test_that("print_ard_conditions(condition_type)", {
         warning("warn1")
         warning("warn2")
         mean(x)
-      }
-      )
+      })
     ) |>
       print_ard_conditions(condition_type = "identity")
   )

--- a/tests/testthat/test-print_ard_conditions.R
+++ b/tests/testthat/test-print_ard_conditions.R
@@ -66,6 +66,37 @@ test_that("print_ard_conditions() works", {
   })
 })
 
+test_that("print_ard_conditions(condition_type)", {
+  # expected warnings as warnings
+  expect_snapshot(
+    ard_continuous(
+      ADSL,
+      variables = AGE,
+      statistic = ~ list(mean_warning = \(x) {
+        warning("warn1")
+        warning("warn2")
+        mean(x)
+      }
+      )
+    ) |>
+      print_ard_conditions(condition_type = "identity")
+  )
+
+  # expected warnings as warnings
+  expect_snapshot(
+    error = TRUE,
+    ard_continuous(
+      ADSL,
+      variables = AGE,
+      statistic = ~ list(
+        mean = \(x) mean(x),
+        err_fn = \(x) stop("'tis an error")
+      )
+    ) |>
+      print_ard_conditions(condition_type = "identity")
+  )
+})
+
 test_that("print_ard_conditions() no error when 'error'/'warning' columns not present", {
   expect_snapshot(
     ard_continuous(


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Added the `print_ard_conditions(condition_type)` argument, which allows users to select to return conditions as messages (the default), or have warnings returned as warnings and errors as errors. (#386)

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #386

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".

_Optional Reverse Dependency Checks_:

Install `checked` with `pak::pak("Genentech/checked")` or `pak::pak("checked")`

```shell
# Check dev versions of `cardx`, `gtsummary`, and `tfrmt` which are in the `ddsjoberg` R Universe
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2L, repos = c('https://ddsjoberg.r-universe.dev', 'https://cloud.r-project.org'))"

# Check CRAN reverse dependencies but run tests skipped on CRAN
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"

# Check CRAN reverse dependencies in a CRAN-like environment
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = FALSE), checked.check_build_args = '--as-cran'); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"
```
