### PR TITLE
Fix in sort order in `nest_for_ard()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Added function `ard_formals()` to assist in adding a function's formals, that is, the arguments with their default values, along with user-passed arguments into an ARD structure.
 
+* Fixed sorting order of logical variables in `nest_for_ard()`. (#411)
+
 # cards 0.5.1
 
 * Small update to account for a change in R-devel.

--- a/R/utils.R
+++ b/R/utils.R
@@ -31,8 +31,8 @@
     )
   }
   if (inherits(x, "logical")) {
-    if (useNA == "no") return(c(TRUE, FALSE))
-    else return(c(TRUE, FALSE, NA))
+    if (useNA == "no") return(c(FALSE, TRUE))
+    else return(c(FALSE, TRUE, NA))
   }
 
   # otherwise, return a simple unique and sort of the vector

--- a/tests/testthat/test-nest_for_ard.R
+++ b/tests/testthat/test-nest_for_ard.R
@@ -16,4 +16,15 @@ test_that("nest_for_ard() works", {
       nrow(),
     16L
   )
+
+  # check order of lgl variables (see Issue #411)
+  expect_equal(
+    mtcars |>
+      dplyr::select(mpg,cyl,am) |>
+      dplyr::mutate(am = as.logical(am)) |>
+      nest_for_ard(by = "am", include_data = FALSE) |>
+      dplyr::pull(group1_level) |>
+      unlist(),
+    c(FALSE, TRUE)
+  )
 })

--- a/tests/testthat/test-nest_for_ard.R
+++ b/tests/testthat/test-nest_for_ard.R
@@ -20,7 +20,6 @@ test_that("nest_for_ard() works", {
   # check order of lgl variables (see Issue #411)
   expect_equal(
     mtcars |>
-      dplyr::select(mpg,cyl,am) |>
       dplyr::mutate(am = as.logical(am)) |>
       nest_for_ard(by = "am", include_data = FALSE) |>
       dplyr::pull(group1_level) |>


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Fixed sorting order of logical variables in `nest_for_ard()`. (#411)

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #411

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".

_Optional Reverse Dependency Checks_:

Install `checked` with `pak::pak("Genentech/checked")` or `pak::pak("checked")`

```shell
# Check dev versions of `cardx`, `gtsummary`, and `tfrmt` which are in the `ddsjoberg` R Universe
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2L, repos = c('https://ddsjoberg.r-universe.dev', 'https://cloud.r-project.org'))"

# Check CRAN reverse dependencies but run tests skipped on CRAN
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"

# Check CRAN reverse dependencies in a CRAN-like environment
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = FALSE), checked.check_build_args = '--as-cran'); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"
```
