### PR TITLE
Sort `ard_stack_hierarchical()` results by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Fixed sorting order of logical variables in `nest_for_ard()`. (#411)
 
+* Updated `ard_stack_hierarchical()` and `ard_stack_hierarchical_count()` to automatically sort results alphanumerically. (#423)
+
 # cards 0.5.1
 
 * Small update to account for a change in R-devel.

--- a/R/ard_stack_hierarchical.R
+++ b/R/ard_stack_hierarchical.R
@@ -455,6 +455,9 @@ internal_stack_hierarchical <- function(data,
   # append attributes used for sorting/filtering -------------------------------
   attr(result, "args") <- list(by = by, variables = variables, include = include)
 
+  # sort ARD alphanumerically --------------------------------------------------
+  result <- result |> sort_ard_hierarchical(sort = "alphanumeric")
+
   # return final result --------------------------------------------------------
   result |> as_card()
 }

--- a/R/sort_ard_hierarchical.R
+++ b/R/sort_ard_hierarchical.R
@@ -71,6 +71,14 @@ sort_ard_hierarchical <- function(x, sort = c("descending", "alphanumeric")) {
 
   x_args <- attributes(x)$args
   by_cols <- if (length(x_args$by) > 0) paste0("group", seq_along(length(x_args$by)), c("", "_level")) else NULL
+
+  # for calculations by highest severity, innermost variable is extracted from by
+  if (length(x_args$by) > 1) {
+    x_args$variables <- c(x_args$variables, x_args$by[-1])
+    x_args$include <- c(x_args$include, x_args$by[-1])
+    x_args$by <- x_args$by[-1]
+  }
+
   outer_cols <- if (length(x_args$variables) > 1) {
     x_args$variables |>
       utils::head(-1) |>

--- a/R/sort_ard_hierarchical.R
+++ b/R/sort_ard_hierarchical.R
@@ -144,7 +144,7 @@ sort_ard_hierarchical <- function(x, sort = c("descending", "alphanumeric")) {
 # this function reformats a hierarchical ARD for sorting
 .ard_reformat_sort <- function(x, sort, by, outer_cols) {
   # reformat data from overall column (if present)
-  is_overall_col <- apply(x, 1, function(x) !isTRUE(any(x %in% by)))
+  is_overall_col <- apply(x, 1, function(x) !isTRUE(any(x %in% by)) || x$context == "attributes")
   if (sum(is_overall_col) > 0 && length(by) > 0) {
     x_overall_col <- x[is_overall_col, ] |>
       cards::rename_ard_groups_shift(shift = length(by)) |>
@@ -184,7 +184,8 @@ sort_ard_hierarchical <- function(x, sort = c("descending", "alphanumeric")) {
         dat |>
           dplyr::mutate(
             group1 = "..empty..",
-            variable = NA
+            group1_level = list(NA),
+            variable = NA,
           )
       } else {
         dat

--- a/tests/testthat/_snaps/ard_stack_hierarchical.md
+++ b/tests/testthat/_snaps/ard_stack_hierarchical.md
@@ -115,22 +115,22 @@
     Output
          group1 group1_level group2 group2_level group3 group3_level variable variable_level stat_name stat_label stat
       1   AESEV         MILD   <NA>                <NA>                 AESOC      GENERAL …         n          n    4
-      2   AESEV         MILD   <NA>                <NA>                 AESOC      SKIN AND…         n          n    1
-      3   AESEV         MILD  AESOC    GENERAL …   <NA>               AEDECOD      APPLICAT…         n          n    2
+      2   AESEV     MODERATE   <NA>                <NA>                 AESOC      GENERAL …         n          n    0
+      3    <NA>                <NA>                <NA>                 AESOC      GENERAL …         n          n    4
       4   AESEV         MILD  AESOC    GENERAL …   <NA>               AEDECOD      APPLICAT…         n          n    2
-      5   AESEV         MILD  AESOC    SKIN AND…   <NA>               AEDECOD       ERYTHEMA         n          n    1
-      6   AESEV         MILD  AESOC    SKIN AND…   <NA>               AEDECOD      PRURITUS…         n          n    0
-      7   AESEV     MODERATE   <NA>                <NA>                 AESOC      GENERAL …         n          n    0
-      8   AESEV     MODERATE   <NA>                <NA>                 AESOC      SKIN AND…         n          n    1
-      9   AESEV     MODERATE  AESOC    GENERAL …   <NA>               AEDECOD      APPLICAT…         n          n    0
-      10  AESEV     MODERATE  AESOC    GENERAL …   <NA>               AEDECOD      APPLICAT…         n          n    0
-      11  AESEV     MODERATE  AESOC    SKIN AND…   <NA>               AEDECOD       ERYTHEMA         n          n    0
-      12  AESEV     MODERATE  AESOC    SKIN AND…   <NA>               AEDECOD      PRURITUS…         n          n    1
-      13   <NA>                <NA>                <NA>                 AESOC      GENERAL …         n          n    4
-      14   <NA>                <NA>                <NA>                 AESOC      SKIN AND…         n          n    2
-      15  AESOC    GENERAL …   <NA>                <NA>               AEDECOD      APPLICAT…         n          n    2
-      16  AESOC    GENERAL …   <NA>                <NA>               AEDECOD      APPLICAT…         n          n    2
-      17  AESOC    SKIN AND…   <NA>                <NA>               AEDECOD       ERYTHEMA         n          n    1
+      5   AESEV     MODERATE  AESOC    GENERAL …   <NA>               AEDECOD      APPLICAT…         n          n    0
+      6   AESOC    GENERAL …   <NA>                <NA>               AEDECOD      APPLICAT…         n          n    2
+      7   AESEV         MILD  AESOC    GENERAL …   <NA>               AEDECOD      APPLICAT…         n          n    2
+      8   AESEV     MODERATE  AESOC    GENERAL …   <NA>               AEDECOD      APPLICAT…         n          n    0
+      9   AESOC    GENERAL …   <NA>                <NA>               AEDECOD      APPLICAT…         n          n    2
+      10  AESEV         MILD   <NA>                <NA>                 AESOC      SKIN AND…         n          n    1
+      11  AESEV     MODERATE   <NA>                <NA>                 AESOC      SKIN AND…         n          n    1
+      12   <NA>                <NA>                <NA>                 AESOC      SKIN AND…         n          n    2
+      13  AESEV         MILD  AESOC    SKIN AND…   <NA>               AEDECOD       ERYTHEMA         n          n    1
+      14  AESEV     MODERATE  AESOC    SKIN AND…   <NA>               AEDECOD       ERYTHEMA         n          n    0
+      15  AESOC    SKIN AND…   <NA>                <NA>               AEDECOD       ERYTHEMA         n          n    1
+      16  AESEV         MILD  AESOC    SKIN AND…   <NA>               AEDECOD      PRURITUS…         n          n    0
+      17  AESEV     MODERATE  AESOC    SKIN AND…   <NA>               AEDECOD      PRURITUS…         n          n    1
       18  AESOC    SKIN AND…   <NA>                <NA>               AEDECOD      PRURITUS…         n          n    1
     Message
       i 4 more variables: context, fmt_fn, warning, error

--- a/tests/testthat/_snaps/filter_ard_hierarchical.md
+++ b/tests/testthat/_snaps/filter_ard_hierarchical.md
@@ -6,16 +6,16 @@
       {cards} data frame: 39 x 15
     Output
          group1 group1_level group2 group2_level group3 group3_level                     variable variable_level stat_name stat_label  stat
-      1    TRTA      Placebo   <NA>                <NA>                                       SEX              M         n          n    13
-      2    TRTA      Placebo   <NA>                <NA>                                       SEX              M         N          N    33
-      3    TRTA      Placebo   <NA>                <NA>                                       SEX              M         p          % 0.394
-      4    TRTA      Placebo   <NA>                <NA>              ..ard_hierarchical_overall..           TRUE         n          n    26
-      5    TRTA      Placebo   <NA>                <NA>              ..ard_hierarchical_overall..           TRUE         N          N    86
-      6    TRTA      Placebo   <NA>                <NA>              ..ard_hierarchical_overall..           TRUE         p          % 0.302
-      7    TRTA      Placebo    SEX            M   <NA>                                      RACE          WHITE         n          n    12
-      8    TRTA      Placebo    SEX            M   <NA>                                      RACE          WHITE         N          N    30
-      9    TRTA      Placebo    SEX            M   <NA>                                      RACE          WHITE         p          %   0.4
-      10   TRTA    Xanomeli…   <NA>                <NA>                                       SEX              M         n          n    24
+      1    <NA>                <NA>                <NA>                                      TRTA        Placebo         n          n    86
+      2    <NA>                <NA>                <NA>                                      TRTA        Placebo         N          N   254
+      3    <NA>                <NA>                <NA>                                      TRTA        Placebo         p          % 0.339
+      4    <NA>                <NA>                <NA>                                      TRTA      Xanomeli…         n          n    84
+      5    <NA>                <NA>                <NA>                                      TRTA      Xanomeli…         N          N   254
+      6    <NA>                <NA>                <NA>                                      TRTA      Xanomeli…         p          % 0.331
+      7    <NA>                <NA>                <NA>                                      TRTA      Xanomeli…         n          n    84
+      8    <NA>                <NA>                <NA>                                      TRTA      Xanomeli…         N          N   254
+      9    <NA>                <NA>                <NA>                                      TRTA      Xanomeli…         p          % 0.331
+      10   TRTA      Placebo   <NA>                <NA>              ..ard_hierarchical_overall..           TRUE         n          n    26
     Message
       i 29 more rows
       i Use `print(n = ...)` to see more rows

--- a/tests/testthat/test-ard_stack_hierarchical.R
+++ b/tests/testthat/test-ard_stack_hierarchical.R
@@ -112,32 +112,40 @@ test_that("ard_stack_hierarchical(by)", {
   )
 
   # check AEDECOD match
+  ard_match <- ard_hierarchical(
+    ADAE_small,
+    variables = c(AESOC, AEDECOD),
+    by = TRTA,
+    id = USUBJID,
+    denominator = ADSL |> dplyr::rename(TRTA = TRT01A)
+  ) |>
+    cards::tidy_ard_row_order()
+  attr(ard_match, "args") <- list(by = "TRTA", variables = c("AESOC", "AEDECOD"), include = c("AESOC", "AEDECOD"))
+
   expect_equal(
     ard |> dplyr::filter(!is.na(group2)),
-    ard_hierarchical(
-      ADAE_small,
-      variables = c(AESOC, AEDECOD),
-      by = TRTA,
-      id = USUBJID,
-      denominator = ADSL |> dplyr::rename(TRTA = TRT01A)
-    ) |>
-      cards::tidy_ard_row_order(),
+    ard_match |>
+      sort_ard_hierarchical("alphanumeric"),
     ignore_attr = TRUE
   )
 
   # check AESOC match
+  ard_match <- ard_hierarchical(
+    ADAE_small |> dplyr::slice_tail(n = 1L, by = c("USUBJID", "TRTA", "AESOC")),
+    variables = AESOC,
+    by = TRTA,
+    id = USUBJID,
+    denominator = ADSL |> dplyr::rename(TRTA = TRT01A)
+  ) |>
+    cards::tidy_ard_row_order()
+  attr(ard_match, "args") <- list(by = "TRTA", variables = c("AESOC"), include = c("AESOC"))
+
   expect_equal(
     ard |>
       dplyr::filter(variable %in% "AESOC") |>
       dplyr::select(-all_ard_group_n(2L)),
-    ard_hierarchical(
-      ADAE_small |> dplyr::slice_tail(n = 1L, by = c("USUBJID", "TRTA", "AESOC")),
-      variables = AESOC,
-      by = TRTA,
-      id = USUBJID,
-      denominator = ADSL |> dplyr::rename(TRTA = TRT01A)
-    ) |>
-      cards::tidy_ard_row_order(),
+    ard_match |>
+      sort_ard_hierarchical("alphanumeric"),
     ignore_attr = TRUE
   )
 })
@@ -206,36 +214,44 @@ test_that("ard_stack_hierarchical(by) with columns not in `denominator`", {
   )
 
   # check the rates for AEDECOD are correct
+  ard_match <- ADAE_small |>
+    dplyr::arrange(USUBJID, TRTA, AESOC, AEDECOD, AESEV) |>
+    dplyr::filter(.by = c(USUBJID, TRTA, AESOC, AEDECOD), dplyr::n() == dplyr::row_number()) |>
+    ard_hierarchical(
+      variables = c(AESOC, AEDECOD),
+      by = c(TRTA, AESEV),
+      denominator = ADSL |> dplyr::rename(TRTA = TRT01A)
+    ) |>
+    tidy_ard_row_order()
+  attr(ard_match, "args") <- list(by = "TRTA", variables = c("AESOC", "AEDECOD", "AESEV"), include = c("AESOC", "AEDECOD", "AESEV"))
+
   expect_equal(
     ard |>
       dplyr::filter(variable == "AEDECOD"),
-    ADAE_small |>
-      dplyr::arrange(USUBJID, TRTA, AESOC, AEDECOD, AESEV) |>
-      dplyr::filter(.by = c(USUBJID, TRTA, AESOC, AEDECOD), dplyr::n() == dplyr::row_number()) |>
-      ard_hierarchical(
-        variables = c(AESOC, AEDECOD),
-        by = c(TRTA, AESEV),
-        denominator = ADSL |> dplyr::rename(TRTA = TRT01A)
-      ) |>
-      tidy_ard_row_order(),
+    ard_match |>
+      sort_ard_hierarchical("alphanumeric"),
     ignore_attr = TRUE,
     ignore_function_env = TRUE
   )
 
   # check the rates for AESOC are correct
+  ard_match <- ADAE_small |>
+    dplyr::arrange(USUBJID, TRTA, AESOC, AESEV) |>
+    dplyr::filter(.by = c(USUBJID, TRTA, AESOC), dplyr::n() == dplyr::row_number()) |>
+    ard_hierarchical(
+      variables = AESOC,
+      by = c(TRTA, AESEV),
+      denominator = ADSL |> dplyr::rename(TRTA = TRT01A)
+    ) |>
+    tidy_ard_row_order()
+  attr(ard_match, "args") <- list(by = "TRTA", variables = c("AESOC", "AESEV"), include = c("AESOC", "AESEV"))
+
   expect_equal(
     ard |>
       dplyr::filter(variable == "AESOC") |>
       rename_ard_columns(),
-    ADAE_small |>
-      dplyr::arrange(USUBJID, TRTA, AESOC, AESEV) |>
-      dplyr::filter(.by = c(USUBJID, TRTA, AESOC), dplyr::n() == dplyr::row_number()) |>
-      ard_hierarchical(
-        variables = AESOC,
-        by = c(TRTA, AESEV),
-        denominator = ADSL |> dplyr::rename(TRTA = TRT01A)
-      ) |>
-      tidy_ard_row_order() |>
+    ard_match |>
+      sort_ard_hierarchical("alphanumeric") |>
       rename_ard_columns(),
     ignore_attr = TRUE,
     ignore_function_env = TRUE
@@ -306,16 +322,22 @@ test_that("ard_stack_hierarchical_count(variables)", {
   )
 
   # check AEDECOD match
+  ard_match <- ard_hierarchical_count(ADAE_small, variables = c(AESOC, AEDECOD))
+  attr(ard_match, "args") <- list(by = NULL, variables = c("AESOC", "AEDECOD"), include = c("AESOC", "AEDECOD"))
+
   expect_equal(
     ard |> dplyr::filter(!is.na(group1)),
-    ard_hierarchical_count(ADAE_small, variables = c(AESOC, AEDECOD)),
+    ard_match |> sort_ard_hierarchical("alphanumeric"),
     ignore_attr = TRUE
   )
 
   # check AESOC match
+  ard_match <- ard_hierarchical_count(ADAE_small, variables = AESOC)
+  attr(ard_match, "args") <- list(by = NULL, variables = "AESOC", include = "AESOC")
+
   expect_equal(
     ard |> dplyr::filter(is.na(group1)) |> dplyr::select(-all_ard_group_n(1L)),
-    ard_hierarchical_count(ADAE_small, variables = AESOC),
+    ard_match |> sort_ard_hierarchical("alphanumeric"),
     ignore_attr = TRUE
   )
 })
@@ -337,18 +359,24 @@ test_that("ard_stack_hierarchical_count(by)", {
   )
 
   # check AEDECOD match
+  ard_match <- ard_hierarchical_count(ADAE_small, variables = c(AESOC, AEDECOD), by = TRTA) |>
+    cards::tidy_ard_row_order()
+  attr(ard_match, "args") <- list(by = "TRTA", variables = c("AESOC", "AEDECOD"), include = c("AESOC", "AEDECOD"))
+
   expect_equal(
     ard |> dplyr::filter(!is.na(group2)),
-    ard_hierarchical_count(ADAE_small, variables = c(AESOC, AEDECOD), by = TRTA) |>
-      cards::tidy_ard_row_order(),
+    ard_match |> sort_ard_hierarchical("alphanumeric"),
     ignore_attr = TRUE
   )
 
   # check AESOC match
+  ard_match <- ard_hierarchical_count(ADAE_small, variables = AESOC, by = TRTA) |>
+    cards::tidy_ard_row_order()
+  attr(ard_match, "args") <- list(by = "TRTA", variables = "AESOC", include = "AESOC")
+
   expect_equal(
     ard |> dplyr::filter(is.na(group2)) |> dplyr::select(-all_ard_group_n(2L)),
-    ard_hierarchical_count(ADAE_small, variables = AESOC, by = TRTA) |>
-      cards::tidy_ard_row_order(),
+    ard_match |> sort_ard_hierarchical("alphanumeric"),
     ignore_attr = TRUE
   )
 })
@@ -550,7 +578,8 @@ test_that("ard_stack_hierarchical_count(attributes)", {
       dplyr::select(-all_missing_columns()),
     ADAE_small |>
       ard_attributes(variables = c(TRTA, AESOC, AEDECOD)) |>
-      dplyr::select(-all_missing_columns()),
+      dplyr::select(-all_missing_columns()) |>
+      dplyr::slice(c(5:6, 1:2, 3:4)),
     ignore_attr = TRUE
   )
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Updated `ard_stack_hierarchical()` and `ard_stack_hierarchical_count()` to automatically sort results alphanumerically. (#423)

Required 2 additional small fixes to the sorting function:
- Including attributes as "overall results" so they are sorted last
- Accounting for ARDs by highest severity, which means the last hierarchy level is specified in `by` instead of `variables`

Closes #423 

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".

_Optional Reverse Dependency Checks_:

Install `checked` with `pak::pak("Genentech/checked")` or `pak::pak("checked")`

```shell
# Check dev versions of `cardx`, `gtsummary`, and `tfrmt` which are in the `ddsjoberg` R Universe
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2L, repos = c('https://ddsjoberg.r-universe.dev', 'https://cloud.r-project.org'))"

# Check CRAN reverse dependencies but run tests skipped on CRAN
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"

# Check CRAN reverse dependencies in a CRAN-like environment
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = FALSE), checked.check_build_args = '--as-cran'); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"
```
