### PR TITLE
Fix `sort_ard_hierarchical()` bug when `overall=TRUE`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Added new function `ard_identity()` for saving pre-calculated statistics in an ARD format. (#379)
 
+* Fix bug in `sort_ard_hierarchical()` when hierarchical ARD has `overall=TRUE`. (#431)
+
 # cards 0.6.0
 
 ## New Features and Functions

--- a/R/ard_complex.R
+++ b/R/ard_complex.R
@@ -14,6 +14,7 @@
 #'   - `full_data`: the full data frame
 #'   - `by`: character vector of the `by` variables
 #'   - `strata`: character vector of the `strata` variables
+#'
 #'   It is unlikely any one function will need _all_ of the above elements,
 #'   and it's recommended the function passed accepts `...` so that any unused
 #'   arguments will be properly ignored. The `...` also allows this function

--- a/R/sort_ard_hierarchical.R
+++ b/R/sort_ard_hierarchical.R
@@ -70,7 +70,14 @@ sort_ard_hierarchical <- function(x, sort = c("descending", "alphanumeric")) {
   sort <- arg_match(sort, error_call = get_cli_abort_call())
 
   x_args <- attributes(x)$args
-  by_cols <- if (length(x_args$by) > 0) paste0("group", rep(seq_len(length(x_args$by)), each = 2), c("", "_level")) else NULL
+  by_cols <- if (length(x_args$by) > 0) paste0("group", seq_along(length(x_args$by)), c("", "_level")) else NULL
+
+  # for calculations by highest severity, innermost variable is extracted from by
+  if (length(x_args$by) > 1) {
+    x_args$variables <- c(x_args$variables, x_args$by[-1])
+    x_args$include <- c(x_args$include, x_args$by[-1])
+    x_args$by <- x_args$by[-1]
+  }
 
   outer_cols <- if (length(x_args$variables) > 1) {
     x_args$variables |>
@@ -145,7 +152,7 @@ sort_ard_hierarchical <- function(x, sort = c("descending", "alphanumeric")) {
 # this function reformats a hierarchical ARD for sorting
 .ard_reformat_sort <- function(x, sort, by, outer_cols) {
   # reformat data from overall column (if present)
-  is_overall_col <- apply(x, 1, function(x) !isTRUE(any(x == by[1])) || x$context == "attributes")
+  is_overall_col <- apply(x, 1, function(x) !isTRUE(any(x %in% by)) || x$context == "attributes")
   if (sum(is_overall_col) > 0 && length(by) > 0) {
     x_overall_col <- x[is_overall_col, ] |>
       cards::rename_ard_groups_shift(shift = length(by)) |>

--- a/man/ard_complex.Rd
+++ b/man/ard_complex.Rd
@@ -49,13 +49,14 @@ and rows in which \code{"variable"} is \code{NA} have been removed.
 \item \code{full_data}: the full data frame
 \item \code{by}: character vector of the \code{by} variables
 \item \code{strata}: character vector of the \code{strata} variables
+}
+
 It is unlikely any one function will need \emph{all} of the above elements,
 and it's recommended the function passed accepts \code{...} so that any unused
 arguments will be properly ignored. The \code{...} also allows this function
 to perhaps be updated in the future with more passed arguments. For example,
 if one needs a second variable from the data frame, the function inputs
-may look like: \code{foo(x, data, ...)}
-}}
+may look like: \code{foo(x, data, ...)}}
 
 \item{fmt_fn}{(\code{\link[=syntax]{formula-list-selector}})\cr
 a named list, a list of formulas,

--- a/tests/testthat/_snaps/ard_stack_hierarchical.md
+++ b/tests/testthat/_snaps/ard_stack_hierarchical.md
@@ -138,15 +138,36 @@
 # ard_stack_hierarchical_count(overall,over_variables)
 
     Code
-      as.data.frame(dplyr::select(dplyr::filter(ard_stack_hierarchical_count(
-        ADAE_small, variables = AESOC, by = TRTA, denominator = dplyr::rename(ADSL,
-          TRTA = ARM), over_variables = TRUE, overall = TRUE), variable ==
-        "..ard_hierarchical_overall.."), all_ard_groups(), "variable", "stat_name",
-      "stat"))
+      as.data.frame(dplyr::select(dplyr::filter(ard_stack_hierarchical_count(ADAE_small, variables = AESOC, by = TRTA, denominator = dplyr::rename(ADSL, TRTA = ARM), over_variables = TRUE, overall = TRUE), variable == "..ard_hierarchical_overall.."),
+      all_ard_groups(), "variable", "stat_name", "stat"))
     Output
         group1         group1_level                     variable stat_name stat
       1   TRTA              Placebo ..ard_hierarchical_overall..         n    2
       2   TRTA Xanomeline High Dose ..ard_hierarchical_overall..         n    2
       3   TRTA  Xanomeline Low Dose ..ard_hierarchical_overall..         n    2
       4   <NA>                 NULL ..ard_hierarchical_overall..         n    6
+
+---
+
+    Code
+      dplyr::filter(ard_stack_hierarchical_count(ADAE_small, variables = c(AESOC, AEDECOD), by = c(TRTA, AESEV), denominator = dplyr::rename(ADSL, TRTA = ARM), overall = TRUE, over_variables = TRUE), !group1 %in% "TRTA" & !group2 %in% "TRTA" & !group3 %in%
+        "TRTA" & !variable %in% "TRTA")
+    Message
+      {cards} data frame: 21 x 15
+    Output
+         group1 group1_level group2 group2_level group3 group3_level                     variable variable_level stat_name stat_label stat
+      1   AESEV         MILD   <NA>                <NA>              ..ard_hierarchical_overall..           TRUE         n          n    5
+      2   AESEV     MODERATE   <NA>                <NA>              ..ard_hierarchical_overall..           TRUE         n          n    1
+      3    <NA>                <NA>                <NA>              ..ard_hierarchical_overall..           TRUE         n          n    6
+      4   AESEV         MILD   <NA>                <NA>                                     AESOC      GENERAL …         n          n    4
+      5   AESEV     MODERATE   <NA>                <NA>                                     AESOC      GENERAL …         n          n    0
+      6    <NA>                <NA>                <NA>                                     AESOC      GENERAL …         n          n    4
+      7   AESEV         MILD  AESOC    GENERAL …   <NA>                                   AEDECOD      APPLICAT…         n          n    2
+      8   AESEV     MODERATE  AESOC    GENERAL …   <NA>                                   AEDECOD      APPLICAT…         n          n    0
+      9   AESOC    GENERAL …   <NA>                <NA>                                   AEDECOD      APPLICAT…         n          n    2
+      10  AESEV         MILD  AESOC    GENERAL …   <NA>                                   AEDECOD      APPLICAT…         n          n    2
+    Message
+      i 11 more rows
+      i Use `print(n = ...)` to see more rows
+      i 4 more variables: context, fmt_fn, warning, error
 

--- a/tests/testthat/test-ard_stack_hierarchical.R
+++ b/tests/testthat/test-ard_stack_hierarchical.R
@@ -547,6 +547,7 @@ test_that("ard_stack_hierarchical_count(over_variables)", {
 })
 
 test_that("ard_stack_hierarchical_count(overall,over_variables)", {
+  withr::local_options(list(width = 250))
   # ensuring we have an overall row grouped by TRTA, and across TRTA levels (nrow=4)
   expect_snapshot(
     ADAE_small |>
@@ -561,6 +562,19 @@ test_that("ard_stack_hierarchical_count(overall,over_variables)", {
       dplyr::select(all_ard_groups(), "variable", "stat_name", "stat") |>
       as.data.frame()
   )
+
+  # both `overall=TRUE` and `over_variables=TRUE` work together with multiple `by` variables present
+  expect_snapshot({
+    ADAE_small |>
+      ard_stack_hierarchical_count(
+        variables = c(AESOC, AEDECOD),
+        by = c(TRTA, AESEV),
+        denominator = ADSL |> dplyr::rename(TRTA = ARM),
+        overall = TRUE,
+        over_variables = TRUE
+      ) |>
+      dplyr::filter(!group1 %in% "TRTA" & !group2 %in% "TRTA" & !group3 %in% "TRTA" & !variable %in% "TRTA")
+  })
 })
 
 

--- a/vignettes/articles/creating-ards.Rmd
+++ b/vignettes/articles/creating-ards.Rmd
@@ -209,7 +209,7 @@ my_ard_one_sample_t_test <- function(data, variable, ...) {
     cards::ard_continuous(
       data = data,
       variables = {{ variable }},
-      statistic = everything() ~ list(t_test = \(x) t.test(x, ...) |> broom::tidy())
+      statistic = everything() ~ list(t_test = t_test_fun)
     ) |>
     dplyr::mutate(context = "t_test_one_sample")
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Fix bug in `sort_ard_hierarchical()` when hierarchical ARD has `overall=TRUE`.

Closes #431 

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".

_Optional Reverse Dependency Checks_:

Install `checked` with `pak::pak("Genentech/checked")` or `pak::pak("checked")`

```shell
# Check dev versions of `cardx`, `gtsummary`, and `tfrmt` which are in the `ddsjoberg` R Universe
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2L, repos = c('https://ddsjoberg.r-universe.dev', 'https://cloud.r-project.org'))"

# Check CRAN reverse dependencies but run tests skipped on CRAN
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"

# Check CRAN reverse dependencies in a CRAN-like environment
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = FALSE), checked.check_build_args = '--as-cran'); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"
```
