### PR TITLE
Fix bug in ard_stack_hierarchical warning for non-unique `id`s

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Fix bug in `sort_ard_hierarchical()` when hierarchical ARD has `overall=TRUE`. (#431)
 
+* Fix bug in `ard_stack_hierarchical()` when `id` values are present in multiple levels of the `by` variables. (#442)
+
 # cards 0.6.0
 
 ## New Features and Functions

--- a/R/ard_hierarchical.R
+++ b/R/ard_hierarchical.R
@@ -93,7 +93,7 @@ ard_hierarchical.data.frame <- function(data,
   )
   data <- dplyr::ungroup(data)
 
-  if (!is_empty(id) && anyDuplicated(data[c(id, variables)]) > 0L) {
+  if (!is_empty(id) && anyDuplicated(data[c(id, by, variables)]) > 0L) {
     cli::cli_warn(c(
       "Duplicate rows found in data for the {.val {id}} column{?s}.",
       "i" = "Percentages/Denominators are not correct."

--- a/R/ard_stack_hierarchical.R
+++ b/R/ard_stack_hierarchical.R
@@ -40,6 +40,7 @@
 #'   variables = c(AESOC, AEDECOD),
 #'   by = TRTA,
 #'   denominator = ADSL |> dplyr::rename(TRTA = ARM),
+#'   id = USUBJID,
 #'   overall = TRUE
 #' )
 #' ```
@@ -57,6 +58,7 @@
 #'   variables = c(AESOC, AEDECOD),
 #'   by = c(TRTA, AESEV),
 #'   denominator = ADSL |> dplyr::rename(TRTA = ARM),
+#'   id = USUBJID,
 #'   overall = TRUE
 #' )
 #' ```

--- a/man/ard_stack_hierarchical.Rd
+++ b/man/ard_stack_hierarchical.Rd
@@ -137,6 +137,7 @@ include results with the code chunk being re-run with \code{by=NULL}.
   variables = c(AESOC, AEDECOD),
   by = TRTA,
   denominator = ADSL |> dplyr::rename(TRTA = ARM),
+  id = USUBJID,
   overall = TRUE
 )
 }\if{html}{\out{</div>}}
@@ -153,6 +154,7 @@ results with \code{by = AESEV} and again with \code{by = NULL}.
   variables = c(AESOC, AEDECOD),
   by = c(TRTA, AESEV),
   denominator = ADSL |> dplyr::rename(TRTA = ARM),
+  id = USUBJID,
   overall = TRUE
 )
 }\if{html}{\out{</div>}}

--- a/tests/testthat/test-ard_stack_hierarchical.R
+++ b/tests/testthat/test-ard_stack_hierarchical.R
@@ -162,6 +162,22 @@ test_that("ard_stack_hierarchical(by) messaging", {
         denominator = ADSL |> dplyr::rename(TRTA = TRT01A)
       )
   )
+
+  # no messaging if `id` values are present in multiple levels of the `by` variables
+  expect_no_warning(
+    suppressMessages(
+      ard_stack_hierarchical(
+        data = ADAE |>
+          dplyr::bind_rows(ADAE |> dplyr::mutate(TRTA = "Total")),
+        variables = c(AESOC, AEDECOD),
+        by = c(TRTA, AESEV),
+        denominator = ADSL |>
+          dplyr::bind_rows(ADSL |> dplyr::mutate(ARM = "Total")) |>
+          dplyr::rename(TRTA = ARM),
+        id = USUBJID
+      )
+    )
+  )
 })
 
 test_that("ard_stack_hierarchical(denominator) messaging", {


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Style this entry in a way that can be copied directly into `NEWS.md`. (#<issue number>, @<username>)

Provide more detail here as needed.

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #442 
closes #443 

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".

_Optional Reverse Dependency Checks_:

Install `checked` with `pak::pak("Genentech/checked")` or `pak::pak("checked")`

```shell
# Check dev versions of `cardx`, `gtsummary`, and `tfrmt` which are in the `ddsjoberg` R Universe
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2L, repos = c('https://ddsjoberg.r-universe.dev', 'https://cloud.r-project.org'))"

# Check CRAN reverse dependencies but run tests skipped on CRAN
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"

# Check CRAN reverse dependencies in a CRAN-like environment
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = FALSE), checked.check_build_args = '--as-cran'); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"
```
