### PR TITLE
447 shuffle bug

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Fix bug in `ard_stack_hierarchical()` when `id` values are present in multiple levels of the `by` variables. (#442)
 
+* Fix bug in `shuffle_ard()` where error is thrown if input is hierarchical results. (#447)
+
 # cards 0.6.0
 
 ## New Features and Functions

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 * Fix bug in `ard_stack_hierarchical()` when `id` values are present in multiple levels of the `by` variables. (#442)
 
-* Fix bug in `shuffle_ard()` where error is thrown if input is hierarchical results. (#447)
+* Fix bug in `shuffle_ard()` where error is thrown if input contains hierarchical results. (#447)
 
 # cards 0.6.0
 

--- a/man/dot-fill_overall_grp_values.Rd
+++ b/man/dot-fill_overall_grp_values.Rd
@@ -17,7 +17,7 @@ data frame
 This function fills the missing values of grouping variables with "Overall
 \verb{variable name}" where relevant. Specifically it will modify grouping values
 from rows with likely overall calculations present (e.g. non-missing
-variable/variable_level, 100 percent missing group variables, and evidence that the
+variable/variable_level, missing group variables, and evidence that the
 \code{variable} has been computed by group in other rows). "Overall" values will
 be populated only for grouping variables that have been used in other calculations
 of the same variable and statistics.

--- a/tests/testthat/_snaps/shuffle_ard.md
+++ b/tests/testthat/_snaps/shuffle_ard.md
@@ -94,6 +94,19 @@
       3        <NA> Overall SEX      AGE           <NA>  continuous         N          N  254
       4        <NA>           F      AGE           <NA>  continuous         N          N  143
 
+---
+
+    Code
+      shuffle_ard(bind_ard(dplyr::slice(ard_categorical(ADSL, by = c(ARM, SEX), variables = AGEGR1), 1), dplyr::slice(ard_categorical(ADSL, by = SEX, variables = AGEGR1), 1), dplyr::slice(ard_categorical(
+        ADSL, variables = AGEGR1), 1)))
+    Output
+      # A tibble: 3 x 8
+        ARM         SEX         variable variable_level context     stat_name stat_label  stat
+        <chr>       <chr>       <chr>    <chr>          <chr>       <chr>     <chr>      <int>
+      1 Placebo     F           AGEGR1   65-80          categorical n         n             22
+      2 Overall ARM F           AGEGR1   65-80          categorical n         n             78
+      3 Overall ARM Overall SEX AGEGR1   65-80          categorical n         n            144
+
 # shuffle_ard fills missing group levels if the group is meaningful for cardx output
 
     Code

--- a/tests/testthat/test-shuffle_ard.R
+++ b/tests/testthat/test-shuffle_ard.R
@@ -111,6 +111,16 @@ test_that("shuffle_ard fills missing group levels if the group is meaningful", {
       shuffle_ard() |>
       as.data.frame()
   )
+
+  # mix of hierarchical group variables - fills overall only if variable has been calculated by group elsewhere
+  expect_snapshot(
+    bind_ard(
+      ard_categorical(ADSL, by = c(ARM, SEX), variables = AGEGR1) |> dplyr::slice(1),
+      ard_categorical(ADSL, by = SEX, variables = AGEGR1) |> dplyr::slice(1),
+      ard_categorical(ADSL, variables = AGEGR1) |> dplyr::slice(1)
+    ) |>
+      shuffle_ard()
+  )
 })
 
 test_that("shuffle_ard doesn't trim off NULL/NA values", {


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Style this entry in a way that can be copied directly into `NEWS.md`. (#<issue number>, @<username>)

Provide more detail here as needed.

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #447 

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".

_Optional Reverse Dependency Checks_:

Install `checked` with `pak::pak("Genentech/checked")` or `pak::pak("checked")`

```shell
# Check dev versions of `cardx`, `gtsummary`, and `tfrmt` which are in the `ddsjoberg` R Universe
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2L, repos = c('https://ddsjoberg.r-universe.dev', 'https://cloud.r-project.org'))"

# Check CRAN reverse dependencies but run tests skipped on CRAN
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"

# Check CRAN reverse dependencies in a CRAN-like environment
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = FALSE), checked.check_build_args = '--as-cran'); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"
```
