### PR TITLE
add by_stats options to stacking functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cards 0.6.1.9010
 
+* Added `ard_stack(.by_stat)` and `ard_stack_hierarchical(by_stat)` arguments that, when `TRUE` (the default), includes a univariate ARD tabulation of the `by` variable in the returned ARD. (#335)
+
 * `shuffle_ard()` passes down the `args` attribute of the input `card` object when present. (#484, @dragosmg)
 
 * Added flexibility to filter by `by` variable level-specific values when using `filter_ard_hierarchical()` to allow for filtering of hierarchical ARDs by difference in two rates. (#438)

--- a/R/ard_stack.R
+++ b/R/ard_stack.R
@@ -30,6 +30,8 @@
 #'   Default is `FALSE`.
 #' @param .total_n (`logical`)\cr
 #'   logical indicating whether to include of `ard_total_n()` in the returned ARD.
+#' @param .by_stats (`logical`)\cr
+#'   logical indicating whether to include overall stats of the `by` variables in the returned ARD.
 #'
 #' @return an ARD data frame of class 'card'
 #' @export
@@ -59,7 +61,8 @@ ard_stack <- function(data,
                       .missing = FALSE,
                       .attributes = FALSE,
                       .total_n = FALSE,
-                      .shuffle = FALSE) {
+                      .shuffle = FALSE,
+                      .by_stats = TRUE) {
   set_cli_abort_call()
 
   # process arguments ----------------------------------------------------------
@@ -74,6 +77,7 @@ ard_stack <- function(data,
   check_scalar_logical(.attributes)
   check_scalar_logical(.shuffle)
   check_scalar_logical(.total_n)
+  check_scalar_logical(.by_stats)
 
   if (is_empty(.by) && isTRUE(.overall)) {
     cli::cli_inform(
@@ -105,7 +109,7 @@ ard_stack <- function(data,
   }
 
   # compute Ns by group / combine main calls -----------------------------------
-  if (!is_empty(by)) {
+  if (!is_empty(by) && isTRUE(.by_stats)) {
     ard_full <- bind_ard(
       ard_list,
       ard_categorical(

--- a/R/ard_stack_hierarchical.R
+++ b/R/ard_stack_hierarchical.R
@@ -100,7 +100,7 @@
 #' @param shuffle (scalar `logical`)\cr
 #'   logical indicating whether to perform `shuffle_ard()` on the final result.
 #'   Default is `FALSE`.
-#' @param .by_stats (`logical`)\cr
+#' @param by_stats (`logical`)\cr
 #'   logical indicating whether to include overall stats of the `by` variables in the returned ARD.
 #'
 #' @return an ARD data frame of class 'card'

--- a/R/ard_stack_hierarchical.R
+++ b/R/ard_stack_hierarchical.R
@@ -100,6 +100,8 @@
 #' @param shuffle (scalar `logical`)\cr
 #'   logical indicating whether to perform `shuffle_ard()` on the final result.
 #'   Default is `FALSE`.
+#' @param .by_stats (`logical`)\cr
+#'   logical indicating whether to include overall stats of the `by` variables in the returned ARD.
 #'
 #' @return an ARD data frame of class 'card'
 #' @name ard_stack_hierarchical
@@ -135,7 +137,8 @@ ard_stack_hierarchical <- function(
     over_variables = FALSE,
     attributes = FALSE,
     total_n = FALSE,
-    shuffle = FALSE) {
+    shuffle = FALSE,
+    by_stats = TRUE) {
   set_cli_abort_call()
 
   # check inputs ---------------------------------------------------------------
@@ -173,7 +176,8 @@ ard_stack_hierarchical <- function(
     over_variables = over_variables,
     attributes = attributes,
     total_n = total_n,
-    shuffle = shuffle
+    shuffle = shuffle,
+    by_stats = by_stats
   )
 }
 
@@ -189,7 +193,8 @@ ard_stack_hierarchical_count <- function(
     over_variables = FALSE,
     attributes = FALSE,
     total_n = FALSE,
-    shuffle = FALSE) {
+    shuffle = FALSE,
+    by_stats = TRUE) {
   set_cli_abort_call()
 
   # check inputs ---------------------------------------------------------------
@@ -219,7 +224,8 @@ ard_stack_hierarchical_count <- function(
     over_variables = over_variables,
     attributes = attributes,
     total_n = total_n,
-    shuffle = shuffle
+    shuffle = shuffle,
+    by_stats = by_stats
   )
 }
 
@@ -236,7 +242,7 @@ internal_stack_hierarchical <- function(
     attributes = FALSE,
     total_n = FALSE,
     shuffle = FALSE,
-    include_uni_by_tab = TRUE) {
+    by_stats = TRUE) {
   # process inputs -------------------------------------------------------------
   check_not_missing(data)
   check_not_missing(variables)
@@ -252,6 +258,7 @@ internal_stack_hierarchical <- function(
   check_scalar_logical(attributes)
   check_scalar_logical(total_n)
   check_scalar_logical(shuffle)
+  check_scalar_logical(by_stats)
 
   # check inputs ---------------------------------------------------------------
   # both variables and include must be specified
@@ -407,7 +414,7 @@ internal_stack_hierarchical <- function(
 
   # add univariate tabulations of by variables ---------------------------------
   if (
-    isTRUE(include_uni_by_tab) &&
+    isTRUE(by_stats) &&
       is.data.frame(denominator) &&
       !is_empty(intersect(by, names(denominator)))
   ) {
@@ -444,7 +451,7 @@ internal_stack_hierarchical <- function(
           attributes = FALSE,
           total_n = FALSE,
           shuffle = FALSE,
-          include_uni_by_tab = FALSE
+          by_stats = FALSE
         ) %>%
           {
             suppressMessages(eval_tidy(.))

--- a/man/ard_stack.Rd
+++ b/man/ard_stack.Rd
@@ -12,7 +12,8 @@ ard_stack(
   .missing = FALSE,
   .attributes = FALSE,
   .total_n = FALSE,
-  .shuffle = FALSE
+  .shuffle = FALSE,
+  .by_stats = TRUE
 )
 }
 \arguments{
@@ -44,6 +45,9 @@ logical indicating whether to include of \code{ard_total_n()} in the returned AR
 \item{.shuffle}{(\code{logical})\cr
 logical indicating whether to perform \code{shuffle_ard()} on the final result.
 Default is \code{FALSE}.}
+
+\item{.by_stats}{(\code{logical})\cr
+logical indicating whether to include overall stats of the \code{by} variables in the returned ARD.}
 }
 \value{
 an ARD data frame of class 'card'

--- a/man/ard_stack_hierarchical.Rd
+++ b/man/ard_stack_hierarchical.Rd
@@ -96,9 +96,6 @@ Default is \code{FALSE}.}
 
 \item{by_stats}{(\code{logical})\cr
 logical indicating whether to include overall stats of the \code{by} variables in the returned ARD.}
-
-\item{.by_stats}{(\code{logical})\cr
-logical indicating whether to include overall stats of the \code{by} variables in the returned ARD.}
 }
 \value{
 an ARD data frame of class 'card'

--- a/man/ard_stack_hierarchical.Rd
+++ b/man/ard_stack_hierarchical.Rd
@@ -17,7 +17,8 @@ ard_stack_hierarchical(
   over_variables = FALSE,
   attributes = FALSE,
   total_n = FALSE,
-  shuffle = FALSE
+  shuffle = FALSE,
+  by_stats = TRUE
 )
 
 ard_stack_hierarchical_count(
@@ -30,7 +31,8 @@ ard_stack_hierarchical_count(
   over_variables = FALSE,
   attributes = FALSE,
   total_n = FALSE,
-  shuffle = FALSE
+  shuffle = FALSE,
+  by_stats = TRUE
 )
 }
 \arguments{
@@ -91,6 +93,12 @@ logical indicating whether to include of \code{ard_total_n(denominator)} in the 
 \item{shuffle}{(scalar \code{logical})\cr
 logical indicating whether to perform \code{shuffle_ard()} on the final result.
 Default is \code{FALSE}.}
+
+\item{by_stats}{(\code{logical})\cr
+logical indicating whether to include overall stats of the \code{by} variables in the returned ARD.}
+
+\item{.by_stats}{(\code{logical})\cr
+logical indicating whether to include overall stats of the \code{by} variables in the returned ARD.}
 }
 \value{
 an ARD data frame of class 'card'

--- a/tests/testthat/test-ard_stack.R
+++ b/tests/testthat/test-ard_stack.R
@@ -361,8 +361,8 @@ test_that("ard_stack() .by_stats argument", {
   expect_equal(
     ard_test,
     bind_ard(
-      ard_continuous(data = mtcars, by = "cyl", variables = "mpg"),
-      ard_dichotomous(data = mtcars, by = "cyl", variables = "vs"),
+      ard_continuous(data = mtcars, c("am", "cyl"), variables = "mpg"),
+      ard_dichotomous(data = mtcars, c("am", "cyl"), variables = "vs"),
       ard_categorical(data = mtcars, variables = "am"),
       ard_categorical(data = mtcars, variables = "cyl"),
       .update = TRUE,

--- a/tests/testthat/test-ard_stack.R
+++ b/tests/testthat/test-ard_stack.R
@@ -321,3 +321,74 @@ test_that("ard_stack(.by) messaging", {
       dplyr::filter(stat_name %in% "N")
   )
 })
+
+test_that("ard_stack() .by_stats argument", {
+  # by stats for 1 variable
+  expect_error(
+    ard_test <- ard_stack(
+      data = mtcars,
+      .by = "cyl",
+      ard_continuous(variables = "mpg"),
+      ard_dichotomous(variables = "vs"),
+      .by_stats = TRUE
+    ),
+    NA
+  )
+
+  expect_equal(
+    ard_test,
+    bind_ard(
+      ard_continuous(data = mtcars, by = "cyl", variables = "mpg"),
+      ard_dichotomous(data = mtcars, by = "cyl", variables = "vs"),
+      ard_categorical(data = mtcars, variables = "cyl"),
+      .update = TRUE,
+      .order = TRUE
+    )
+  )
+
+  # by stats for 2 variables
+  expect_error(
+    ard_test <- ard_stack(
+      data = mtcars,
+      .by = c("am", "cyl"),
+      ard_continuous(variables = "mpg"),
+      ard_dichotomous(variables = "vs"),
+      .by_stats = TRUE
+    ),
+    NA
+  )
+
+  expect_equal(
+    ard_test,
+    bind_ard(
+      ard_continuous(data = mtcars, by = "cyl", variables = "mpg"),
+      ard_dichotomous(data = mtcars, by = "cyl", variables = "vs"),
+      ard_categorical(data = mtcars, variables = "am"),
+      ard_categorical(data = mtcars, variables = "cyl"),
+      .update = TRUE,
+      .order = TRUE
+    )
+  )
+
+  # no by stats
+  expect_error(
+    ard_test <- ard_stack(
+      data = mtcars,
+      .by = c("am", "cyl"),
+      ard_continuous(variables = "mpg"),
+      ard_dichotomous(variables = "vs"),
+      .by_stats = FALSE
+    ),
+    NA
+  )
+
+  expect_equal(
+    ard_test,
+    bind_ard(
+      ard_continuous(data = mtcars, by = c("am", "cyl"), variables = "mpg"),
+      ard_dichotomous(data = mtcars, by = c("am", "cyl"), variables = "vs"),
+      .update = TRUE,
+      .order = TRUE
+    )
+  )
+})

--- a/tests/testthat/test-ard_stack_hierarchical.R
+++ b/tests/testthat/test-ard_stack_hierarchical.R
@@ -668,3 +668,45 @@ test_that("ard_stack_hierarchical_count(attributes)", {
     ignore_attr = TRUE
   )
 })
+
+test_that("ard_stack_hierarchical() by_stats argument", {
+  # include by_stats
+  expect_silent(
+    ard <-
+      ard_stack_hierarchical(
+        ADAE_small,
+        variables = c(AESOC, AEDECOD),
+        by = TRTA,
+        id = USUBJID,
+        denominator = ADSL,
+        by_stats = TRUE
+      )
+  )
+
+  expect_equal(
+    ard |> dplyr::filter(variable == "TRTA") |> dplyr::select(-all_ard_groups()),
+    ard_categorical(
+      data = ADSL,
+      variables = TRTA
+    ),
+    ignore_attr = TRUE
+  )
+
+  # no by_stats
+  expect_silent(
+    ard <-
+      ard_stack_hierarchical(
+        ADAE_small,
+        variables = c(AESOC, AEDECOD),
+        by = TRTA,
+        id = USUBJID,
+        denominator = ADSL,
+        by_stats = FALSE
+      )
+  )
+
+  expect_equal(
+    ard |> dplyr::filter(variable == "TRTA") |> nrow(),
+    0
+  )
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Style this entry in a way that can be copied directly into `NEWS.md`. (#<issue number>, @<username>)

Provide more detail here as needed.

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #335 

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] Approve Pull Request
- [x] Merge the PR. Please use "Squash and merge" or "Rebase and merge".

_Optional Reverse Dependency Checks_:

Install `checked` with `pak::pak("Genentech/checked")` or `pak::pak("checked")`

```shell
# Check dev versions of `cardx`, `gtsummary`, and `tfrmt` which are in the `ddsjoberg` R Universe
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2L, repos = c('https://ddsjoberg.r-universe.dev', 'https://cloud.r-project.org'))"

# Check CRAN reverse dependencies but run tests skipped on CRAN
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"

# Check CRAN reverse dependencies in a CRAN-like environment
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = FALSE), checked.check_build_args = '--as-cran'); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"
```
