### PR TITLE
Add option to sort hierarchical ARDs differently at each level

### DIFF
--- a/R/filter_ard_hierarchical.R
+++ b/R/filter_ard_hierarchical.R
@@ -373,7 +373,7 @@ filter_ard_hierarchical <- function(x, filter, var = NULL, keep_empty = FALSE, q
         names()
       x_no_sum <- x |>
         dplyr::mutate(idx = dplyr::row_number()) |>
-        .ard_reformat_sort("no_sort", by, outer_cols)
+        .ard_reformat_sort(by, outer_cols)
       # check if each hierarchy section (from innermost to outermost) is empty and if so remove its summary row
       for (i in rev(seq_along(outer_cols))) {
         x_no_sum <- x_no_sum |>

--- a/R/filter_ard_hierarchical.R
+++ b/R/filter_ard_hierarchical.R
@@ -363,39 +363,51 @@ filter_ard_hierarchical <- function(x, filter, var = NULL, keep_empty = FALSE, q
 
   # remove summary rows from empty sections if requested
   if (var != ard_args$variables[1] && !keep_empty && length(ard_args$include) > 1) {
-    outer_cols <- ard_args$variables |> utils::head(-1)
+    cols <-
+      ard_args$variables |>
+      stats::setNames(
+        x |>
+          dplyr::select(all_ard_group_n(seq_along(ard_args$variables) + length(by), types = "names"), "variable") |>
+          names()
+      )
+    outer_cols <- head(cols, -1)
     # if all inner rows filtered out, remove all summary rows - only overall/header rows left
     if (!dplyr::last(ard_args$variables) %in% x$variable) {
       x <- x |> dplyr::filter(!.data$variable %in% outer_cols)
     } else {
-      names(outer_cols) <- x |>
-        dplyr::select(all_ard_groups("names"), -all_of(by_cols)) |>
-        names()
-      x_no_sum <- x |>
+      x_sum <- x |>
         dplyr::mutate(idx = dplyr::row_number()) |>
-        .ard_reformat_sort(by, outer_cols)
+        # reformat current variable columns for filtering
+        .ard_reformat_sort(by, cols)
+
       # check if each hierarchy section (from innermost to outermost) is empty and if so remove its summary row
       for (i in rev(seq_along(outer_cols))) {
-        x_no_sum <- x_no_sum |>
-          dplyr::group_by(across(c(all_ard_group_n((1:i) + length(by)), -all_of(by_cols)))) |>
-          dplyr::group_map(
-            function(.df, .y) {
-              cur_var <- .y[[ncol(.y) - 1]]
-              if (cur_var == "..empty..") {
-                .df
-              } else {
-                inner_rows <- .df |> dplyr::filter(.data$variable != cur_var)
-                if (nrow(inner_rows) > 0) .df else NULL
-              }
-            },
-            .keep = TRUE
-          ) |>
-          dplyr::bind_rows()
+        # get group keys of all non-empty sections
+        x_gps <- x_sum |>
+          # group by current and all previous grouping columns
+          dplyr::group_by(pick(
+            any_of(cards::all_ard_group_n((1:i) + length(by))),
+            any_of(cards::all_ard_variables())
+          )) |>
+          dplyr::group_keys() |>
+          dplyr::filter(!variable %in% "..overall..") |>
+          dplyr::select(any_of(cards::all_ard_group_n((1:i) + length(by)))) |>
+          dplyr::distinct()
+
+        # get indices of rows to remove (summary rows from empty sections)
+        idx_rm <- x_sum |>
+          dplyr::filter(.data[[names(cols)[i]]] %in% cols[i]) |>
+          dplyr::anti_join(x_gps, by = names(x_gps)) |>
+          dplyr::pull(idx)
+
+        # remove summary rows from empty sections
+        x_sum <- x_sum |>
+          dplyr::filter(!idx %in% idx_rm)
       }
-      idx_no_sum <- sort(x_no_sum$idx)
-      x <- x[idx_no_sum, ]
+      # filter out all empty summary rows
+      idx_keep <- sort(x_sum$idx)
+      x <- x[idx_keep, ]
     }
   }
-
   as_card(x)
 }

--- a/R/sort_ard_hierarchical.R
+++ b/R/sort_ard_hierarchical.R
@@ -109,6 +109,15 @@ sort_ard_hierarchical <- function(x, sort = everything() ~ "descending") {
         names()
     )
 
+  # attributes and total n not sorted - appended to bottom of sorted ARD
+  has_attr <- "attributes" %in% x$context | "total_n" %in% x$context
+  if (has_attr) {
+    x_attr <- x |>
+      dplyr::filter(context %in% c("attributes", "total_n"))
+    x <- x |>
+      dplyr::filter(!context %in% c("attributes", "total_n"))
+  }
+
   # header row info not sorted - appended to top of sorted ARD
   has_hdr <- !is_empty(by) | "..ard_hierarchical_overall.." %in% x$variable
   if (has_hdr) {
@@ -118,15 +127,6 @@ sort_ard_hierarchical <- function(x, sort = everything() ~ "descending") {
       dplyr::arrange(dplyr::desc(.data$variable))
     x <- x |>
       dplyr::filter(!variable %in% c(by, "..ard_hierarchical_overall.."))
-  }
-
-  # attributes and total n not sorted - appended to bottom of sorted ARD
-  has_attr <- "attributes" %in% x$context | "total_n" %in% x$context
-  if (has_attr) {
-    x_attr <- x |>
-      dplyr::filter(context %in% c("attributes", "total_n"))
-    x <- x |>
-      dplyr::filter(!context %in% c("attributes", "total_n"))
   }
 
   # reformat ARD for sorting ---------------------------------------------------------------------

--- a/R/sort_ard_hierarchical.R
+++ b/R/sort_ard_hierarchical.R
@@ -226,7 +226,7 @@ sort_ard_hierarchical <- function(x, sort = everything() ~ "descending") {
           # to sort them prior to non-summary rows in the same section
           !!cur_var :=
             dplyr::case_when(
-              !is_empty(by) & .data$group1 %in% c(by, NA) ~ "..empty..",
+              .data$variable %in% "..overall.." ~ "..empty..",
               .default = NA
             ),
           !!cur_var_lvl := as.list(NA)

--- a/R/sort_ard_hierarchical.R
+++ b/R/sort_ard_hierarchical.R
@@ -123,7 +123,7 @@ sort_ard_hierarchical <- function(x, sort = everything() ~ "descending") {
     dplyr::mutate(idx = dplyr::row_number()) |>
     dplyr::mutate(
       variable_level =
-        if_else(.data$variable %in% c("..ard_hierarchical_overall..", "..ard_total_n.."), list(NA), variable_level)
+        dplyr::if_else(.data$variable %in% c("..ard_hierarchical_overall..", "..ard_total_n.."), list(NA), variable_level)
     )
 
   for (i in seq_along(x_args$variables)) {
@@ -166,8 +166,8 @@ sort_ard_hierarchical <- function(x, sort = everything() ~ "descending") {
   if (!is_empty(by) & i == 1) {
     x <- x |>
       dplyr::mutate(
-        !!cur_var := if_else(!is_empty(by) & .data$variable %in% by, "..empty..", .data[[cur_var]]),
-        !!cur_var_lvl := if_else(!is_empty(by) & .data$variable %in% by, as.list(NA), .data[[cur_var_lvl]])
+        !!cur_var := dplyr::if_else(!is_empty(by) & .data$variable %in% by, "..empty..", .data[[cur_var]]),
+        !!cur_var_lvl := dplyr::if_else(!is_empty(by) & .data$variable %in% by, as.list(NA), .data[[cur_var_lvl]])
       )
   }
 
@@ -238,7 +238,6 @@ sort_ard_hierarchical <- function(x, sort = everything() ~ "descending") {
   sort_stat <- if (n_all) "n" else "p"
 
   sum_i <- paste0("sum_group_", i)
-
   x_sums <- x |>
     dplyr::filter(
       .data$stat_name == sort_stat,
@@ -246,7 +245,7 @@ sort_ard_hierarchical <- function(x, sort = everything() ~ "descending") {
       if (!is_empty(x_args$by)) !.data$group1 %in% x_args$variables
     ) |>
     dplyr::summarize(!!sum_i := sum(unlist(.data$stat[.data$stat_name == sort_stat]))) |>
-    ungroup()
+    dplyr::ungroup()
 
   if (i == 1) {
     x_sums[x_sums[[cur_var]] %in% "..overall..", sum_i] <- max(x_sums[[sum_i]], na.rm = TRUE) + 1
@@ -255,9 +254,9 @@ sort_ard_hierarchical <- function(x, sort = everything() ~ "descending") {
 
   sort_cols <- append(dplyr::group_vars(x), sum_i, after = length(dplyr::group_vars(x)) - 2)
   x_sums <- x_sums |>
-    dplyr::arrange(across(sort_cols, \(x) if (is.numeric(x)) desc(x) else x)) |>
+    dplyr::arrange(across(sort_cols, \(x) if (is.numeric(x)) dplyr::desc(x) else x)) |>
     dplyr::mutate(!!paste0("sort_group_", i) := dplyr::row_number())
 
   x |>
-    left_join(x_sums, by = group_vars(x))
+    dplyr::left_join(x_sums, by = dplyr::group_vars(x))
 }

--- a/man/sort_ard_hierarchical.Rd
+++ b/man/sort_ard_hierarchical.Rd
@@ -4,7 +4,7 @@
 \alias{sort_ard_hierarchical}
 \title{Sort Stacked Hierarchical ARDs}
 \usage{
-sort_ard_hierarchical(x, sort = c("descending", "alphanumeric"))
+sort_ard_hierarchical(x, sort = everything() ~ "descending")
 }
 \arguments{
 \item{x}{(\code{card})\cr
@@ -57,7 +57,7 @@ ard_stack_hierarchical_count(
   by = TRTA,
   denominator = ADSL
 ) |>
-  sort_ard_hierarchical("descending")
+  sort_ard_hierarchical(sort = list(AESOC ~ "alphanumeric", AEDECOD ~ "descending"))
 \dontshow{\}) # examplesIf}
 }
 \seealso{

--- a/man/sort_ard_hierarchical.Rd
+++ b/man/sort_ard_hierarchical.Rd
@@ -11,18 +11,22 @@ sort_ard_hierarchical(x, sort = everything() ~ "descending")
 a stacked hierarchical ARD of class \code{'card'} created using \code{\link[=ard_stack_hierarchical]{ard_stack_hierarchical()}} or
 \code{\link[=ard_stack_hierarchical_count]{ard_stack_hierarchical_count()}}.}
 
-\item{sort}{(\code{string})\cr
-type of sorting to perform. Value must be one of:
+\item{sort}{(\code{\link[=syntax]{formula-list-selector}}, \code{string})\cr
+a named list, a list of formulas, a single formula where the list element is a named list of functions
+(or the RHS of a formula), or a string specifying the types of sorting to perform at each hierarchy variable level.
+If sort method for any variable is not specified then the sort method will default to \code{"descending"}. If a single
+unnamed string is supplied, it is applied to all variables. For each variable, the value specified must
+be one of:
 \itemize{
-\item \code{"alphanumeric"} - within each hierarchical section of the ARD, groups are ordered alphanumerically (i.e. A to Z)
-by \code{variable_level} text.
-\item \code{"descending"} - within each variable group of the ARD, count sums are calculated for each group and groups are
-sorted in descending order by sum. If \code{sort = "descending"}, the \code{n} statistic is used to calculate variable
-group sums if included in \code{statistic} for all variables, otherwise \code{p} is used. If neither \code{n} nor \code{p} are
-present in \code{x} for all variables, an error will occur.
+\item \code{"alphanumeric"} - at the specified hierarchical variable level of the ARD, groups are ordered alphanumerically
+(i.e. A to Z) by \code{variable_level} text.
+\item \code{"descending"} - within each variable group of the ARD at the specified hierarchy variable level, count sums are
+calculated for each group and groups are sorted in descending order by sum. When \code{sort} is \code{"descending"} for a
+given variable and \code{n} is included in \code{statistic} for the variable then \code{n} is used to calculate variable group
+sums, otherwise \code{p} is used. If neither \code{n} nor \code{p} are present in \code{x} for the variable, an error will occur.
 }
 
-Defaults to \code{"descending"}.}
+Defaults to \code{everything() ~ "descending"}.}
 }
 \value{
 an ARD data frame of class 'card'
@@ -49,7 +53,7 @@ ard_stack_hierarchical(
   denominator = ADSL,
   id = USUBJID
 ) |>
-  sort_ard_hierarchical("alphanumeric")
+  sort_ard_hierarchical(AESOC ~ "alphanumeric")
 
 ard_stack_hierarchical_count(
   ADAE,

--- a/tests/testthat/_snaps/sort_ard_hierarchical.md
+++ b/tests/testthat/_snaps/sort_ard_hierarchical.md
@@ -82,5 +82,5 @@
       sort_ard_hierarchical(ard)
     Condition
       Error in `sort_ard_hierarchical()`:
-      ! If `sort='descending'` then either "n" or "p" must be present in `x` for all variables in order to calculate the count sums used for sorting.
+      ! If `sort='descending'` for any variables then either "n" or "p" must be present in `x` for each of these specified variables in order to calculate the count sums used for sorting.
 

--- a/tests/testthat/_snaps/sort_ard_hierarchical.md
+++ b/tests/testthat/_snaps/sort_ard_hierarchical.md
@@ -74,7 +74,7 @@
       sort_ard_hierarchical(ard, sort = "no_sorting")
     Condition
       Error in `sort_ard_hierarchical()`:
-      ! `sort` must be one of "descending" or "alphanumeric", not "no_sorting".
+      ! Sorting type must be either "descending" or "alphanumeric" for all variables.
 
 ---
 

--- a/tests/testthat/test-sort_ard_hierarchical.R
+++ b/tests/testthat/test-sort_ard_hierarchical.R
@@ -156,6 +156,75 @@ test_that("sort_ard_hierarchical(sort = 'alphanumeric') works", {
   )
 })
 
+test_that("sort_ard_hierarchical(sort) works with different sorting methods for each variable", {
+  expect_silent(
+    ard <- sort_ard_hierarchical(
+      ard,
+      sort = list(SEX ~ "alphanumeric", RACE = "descending", AETERM = "alphanumeric")
+    )
+  )
+
+  expect_equal(
+    ard |>
+      dplyr::filter(variable == "SEX") |>
+      dplyr::select(variable_level) |>
+      dplyr::distinct() |>
+      dplyr::pull(variable_level) |>
+      unlist(),
+    sort(c("F", "M"))
+  )
+  expect_equal(
+    ard |>
+      dplyr::filter(variable == "RACE") |>
+      dplyr::select(
+        all_ard_groups("levels"),
+        -"group1_level",
+        all_ard_variables()
+      ) |>
+      dplyr::distinct() |>
+      dplyr::pull(variable_level) |>
+      unlist(),
+    c(
+      "WHITE",
+      "BLACK OR AFRICAN AMERICAN",
+      "WHITE",
+      "BLACK OR AFRICAN AMERICAN",
+      "AMERICAN INDIAN OR ALASKA NATIVE"
+    )
+  )
+  expect_equal(
+    ard |>
+      dplyr::filter(variable == "AETERM") |>
+      dplyr::select(
+        all_ard_groups("levels"),
+        -"group1_level",
+        all_ard_variables()
+      ) |>
+      dplyr::distinct() |>
+      dplyr::pull(variable_level) |>
+      unlist(),
+    c(
+      "APPLICATION SITE ERYTHEMA",
+      "APPLICATION SITE PRURITUS",
+      "DIARRHOEA",
+      "ERYTHEMA",
+      "APPLICATION SITE PRURITUS",
+      "ATRIOVENTRICULAR BLOCK SECOND DEGREE",
+      "DIARRHOEA",
+      "ERYTHEMA",
+      "APPLICATION SITE ERYTHEMA",
+      "APPLICATION SITE PRURITUS",
+      "ATRIOVENTRICULAR BLOCK SECOND DEGREE",
+      "DIARRHOEA",
+      "ERYTHEMA",
+      "APPLICATION SITE PRURITUS",
+      "DIARRHOEA",
+      "ERYTHEMA",
+      "ERYTHEMA"
+    )
+  )
+})
+
 test_that("sort_ard_hierarchical() works when there is no overall row in x", {
   ard_no_overall <- ard_stack_hierarchical(
     data = ADAE_subset,


### PR DESCRIPTION
**What changes are proposed in this pull request?**
- Refactored `sort_ard_hierarchical()` to allowing for different sorting methods at each hierarchy variable level. (#487)
- Updated `sort_ard_hierarchical()` and `filter_ard_hierarchical()` to always keep attribute and total N rows at the bottom of the ARD.

This turned out a lot bigger than I first expected but I think it's a lot more readable than it was previously and will be easier to debug in the future. Ultimately it's the same processing as was done previously but separated out into an iterative process so each variable can be considered separately.

Small updates were needed to `filter_ard_hierarchical()` as well which uses the same reformatting function when processing the ARD.

Closes #487 

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".

_Optional Reverse Dependency Checks_:

Install `checked` with `pak::pak("Genentech/checked")` or `pak::pak("checked")`

```shell
# Check dev versions of `cardx`, `gtsummary`, and `tfrmt` which are in the `ddsjoberg` R Universe
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2L, repos = c('https://ddsjoberg.r-universe.dev', 'https://cloud.r-project.org'))"

# Check CRAN reverse dependencies but run tests skipped on CRAN
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"

# Check CRAN reverse dependencies in a CRAN-like environment
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = FALSE), checked.check_build_args = '--as-cran'); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"
```
