### PR TITLE
retain strata values when nesting

### DIFF
--- a/R/nest_for_ard.R
+++ b/R/nest_for_ard.R
@@ -119,7 +119,7 @@ nest_for_ard <- function(data, by = NULL, strata = NULL, key = "data",
         seq_len(nrow(df_return)),
         FUN = function(i) {
           dplyr::filter(data, !!!lst_filter_exprs[[i]]) |>
-            dplyr::select(-all_of(.env$by), -all_of(.env$strata))
+            dplyr::select(-all_of(.env$by))
         }
       )
   }

--- a/tests/testthat/test-ard_strata.R
+++ b/tests/testthat/test-ard_strata.R
@@ -35,3 +35,16 @@ test_that("ard_strata(by,strata) when both empty", {
     ard_continuous(ADSL, by = ARM, variables = AGE)
   )
 })
+
+test_that("nest_for_ard retains strata in nested data", {
+  df <- tibble::tibble(
+    PARAMCD = rep(c("A", "B"), each = 2),
+    VALUE = 1:4
+  )
+
+  nested <- nest_for_ard(df, strata = "PARAMCD")
+
+  expect_true("PARAMCD" %in% names(nested))
+  expect_true("data" %in% names(nested))
+  expect_true(all(purrr::map_lgl(nested$data, ~ "PARAMCD" %in% names(.x))))
+})


### PR DESCRIPTION
closes #461 

update nest_for_ard to retain strata value in the result dataframe.
--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".

_Optional Reverse Dependency Checks_:

Install `checked` with `pak::pak("Genentech/checked")` or `pak::pak("checked")`

```shell
# Check dev versions of `cardx`, `gtsummary`, and `tfrmt` which are in the `ddsjoberg` R Universe
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2L, repos = c('https://ddsjoberg.r-universe.dev', 'https://cloud.r-project.org'))"

# Check CRAN reverse dependencies but run tests skipped on CRAN
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"

# Check CRAN reverse dependencies in a CRAN-like environment
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = FALSE), checked.check_build_args = '--as-cran'); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"
```
