### PR TITLE
Only by and id for denominator (fixes 482)

### DIFF
--- a/R/ard_stack_hierarchical.R
+++ b/R/ard_stack_hierarchical.R
@@ -337,6 +337,18 @@ internal_stack_hierarchical <- function(
     }
   }
 
+  # only id and by variables in denominator
+  if (is.data.frame(denominator)) {
+    # keep any id columns that are actually in the denominator, and any by columns that exist in denominator
+    keep_cols <- unique(c(intersect(id, names(denominator)), intersect(by, names(denominator))))
+
+    # only trim if there is at least one column to keep; otherwise leave denominator as-is
+    if (!is_empty(keep_cols)) {
+      # drop any columns that are also in `variables` (or any other cols)
+      denominator <- denominator[ , keep_cols, drop = FALSE]
+    }
+  }
+
   # sort data if using `ard_hierarchical(id)` ----------------------------------
   if (!is_empty(id)) {
     data <- dplyr::arrange(data, dplyr::pick(all_of(c(id, by, variables))))

--- a/tests/testthat/test-ard_stack_hierarchical.R
+++ b/tests/testthat/test-ard_stack_hierarchical.R
@@ -209,6 +209,35 @@ test_that("ard_stack_hierarchical(denominator) messaging", {
       id = USUBJID
     )
   )
+
+
+  # check denominator only keeps "by" and "id" variables
+  adsl_updated <-
+    cards::ADSL |>
+    dplyr::mutate(
+      REGION = "Asia",
+      COUNTRY = sample(c("CHN", "JPN", "PAK"), size = dplyr::n(), replace = TRUE)
+    )
+
+  expect_equal(
+    cards::ard_stack_hierarchical(
+      adsl_updated,
+      by = "ARM",
+      variable = c("REGION", "COUNTRY"),
+      id = "USUBJID",
+      denominator = adsl_updated
+    ),
+    cards::ard_stack_hierarchical(
+      adsl_updated,
+      by = "ARM",
+      variable = c("REGION", "COUNTRY"),
+      id = "USUBJID",
+      denominator = adsl_updated[c("USUBJID", "ARM")]
+    ),
+    ignore_attr = TRUE,
+    ignore_function_env = TRUE
+  )
+
 })
 
 # test the rates are correct for items like AESEV, where we want to tabulate the most severe AE within the hierarchies


### PR DESCRIPTION
**Denominator only keeps id and by variables (if present)**

Update so that denominator dataset does not containing vars from "variables" argument, only from "id" and "by" arguments

Addresses #482 


--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [X] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [X] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".

_Optional Reverse Dependency Checks_:

Install `checked` with `pak::pak("Genentech/checked")` or `pak::pak("checked")`

```shell
# Check dev versions of `cardx`, `gtsummary`, and `tfrmt` which are in the `ddsjoberg` R Universe
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2L, repos = c('https://ddsjoberg.r-universe.dev', 'https://cloud.r-project.org'))"

# Check CRAN reverse dependencies but run tests skipped on CRAN
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"

# Check CRAN reverse dependencies in a CRAN-like environment
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = FALSE), checked.check_build_args = '--as-cran'); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"
```
