### PR TITLE
only by and id for denominator (fixes #482) - redo of original with A…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # cards 0.7.0.9001
 
+## New Features and Functions
+
+* Updated `ard_stack_hierarchical()` so that the `denominator` dataset only contains the `id` and `by` variables. (#482)
+
 # cards 0.7.0
 
 ## New Features and Functions

--- a/R/ard_stack_hierarchical.R
+++ b/R/ard_stack_hierarchical.R
@@ -337,6 +337,18 @@ internal_stack_hierarchical <- function(
     }
   }
 
+  # only id and by variables in denominator
+  if (is.data.frame(denominator)) {
+    # keep any id columns that are actually in the denominator, and any by columns that exist in denominator
+    keep_cols <- intersect(c(id, by), names(denominator))
+
+    # only trim if there is at least one column to keep; otherwise leave denominator as-is
+    if (!is_empty(keep_cols)) {
+      # drop any columns that are also in `variables` (or any other cols)
+      denominator <- denominator[, keep_cols, drop = FALSE]
+    }
+  }
+
   # sort data if using `ard_hierarchical(id)` ----------------------------------
   if (!is_empty(id)) {
     data <- dplyr::arrange(data, dplyr::pick(all_of(c(id, by, variables))))

--- a/R/ard_stack_hierarchical.R
+++ b/R/ard_stack_hierarchical.R
@@ -337,16 +337,9 @@ internal_stack_hierarchical <- function(
     }
   }
 
-  # only id and by variables in denominator
+  # keep only `id` and `by` variables in `denominator`
   if (is.data.frame(denominator)) {
-    # keep any id columns that are actually in the denominator, and any by columns that exist in denominator
-    keep_cols <- intersect(c(id, by), names(denominator))
-
-    # only trim if there is at least one column to keep; otherwise leave denominator as-is
-    if (!is_empty(keep_cols)) {
-      # drop any columns that are also in `variables` (or any other cols)
-      denominator <- denominator[, keep_cols, drop = FALSE]
-    }
+    denominator <- denominator[, intersect(c(id, by), names(denominator)), drop = FALSE]
   }
 
   # sort data if using `ard_hierarchical(id)` ----------------------------------

--- a/man/cards-package.Rd
+++ b/man/cards-package.Rd
@@ -6,6 +6,8 @@
 \alias{cards-package}
 \title{cards: Analysis Results Data}
 \description{
+\if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
+
 Construct CDISC (Clinical Data Interchange Standards Consortium) compliant Analysis Results Data objects. These objects are used and re-used to construct summary tables, visualizations, and written reports. The package also exports utilities for working with these objects and creating new Analysis Results Data objects.
 }
 \seealso{

--- a/man/cards-package.Rd
+++ b/man/cards-package.Rd
@@ -6,8 +6,6 @@
 \alias{cards-package}
 \title{cards: Analysis Results Data}
 \description{
-\if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
-
 Construct CDISC (Clinical Data Interchange Standards Consortium) compliant Analysis Results Data objects. These objects are used and re-used to construct summary tables, visualizations, and written reports. The package also exports utilities for working with these objects and creating new Analysis Results Data objects.
 }
 \seealso{

--- a/tests/testthat/test-ard_stack_hierarchical.R
+++ b/tests/testthat/test-ard_stack_hierarchical.R
@@ -209,6 +209,33 @@ test_that("ard_stack_hierarchical(denominator) messaging", {
       id = USUBJID
     )
   )
+
+  # check denominator only keeps "by" and "id" variables
+  adsl_updated <-
+    cards::ADSL |>
+    dplyr::mutate(
+      REGION = "Asia",
+      COUNTRY = sample(c("CHN", "JPN", "PAK"), size = dplyr::n(), replace = TRUE)
+    )
+
+  expect_equal(
+    cards::ard_stack_hierarchical(
+      adsl_updated,
+      by = "ARM",
+      variable = c("REGION", "COUNTRY"),
+      id = "USUBJID",
+      denominator = adsl_updated
+    ),
+    cards::ard_stack_hierarchical(
+      adsl_updated,
+      by = "ARM",
+      variable = c("REGION", "COUNTRY"),
+      id = "USUBJID",
+      denominator = adsl_updated[c("USUBJID", "ARM")]
+    ),
+    ignore_attr = TRUE,
+    ignore_function_env = TRUE
+  )
 })
 
 # test the rates are correct for items like AESEV, where we want to tabulate the most severe AE within the hierarchies

--- a/tests/testthat/test-filter_ard_hierarchical.R
+++ b/tests/testthat/test-filter_ard_hierarchical.R
@@ -21,12 +21,12 @@ test_that("filter_ard_hierarchical() works", {
   expect_equal(nrow(ard_f), 45)
 
   expect_silent(ard_f <- filter_ard_hierarchical(ard, p > 0.05))
-  expect_equal(nrow(ard_f), 234)
+  expect_equal(nrow(ard_f), 117)
 })
 
 test_that("filter_ard_hierarchical() works with non-standard filters", {
-  expect_silent(ard_f <- filter_ard_hierarchical(ard, n == 2 & p < 0.05))
-  expect_equal(nrow(ard_f), 63)
+  expect_silent(ard_f <- filter_ard_hierarchical(ard, n == 2 & p < 0.02))
+  expect_equal(nrow(ard_f), 18)
 
   expect_silent(ard_f <- filter_ard_hierarchical(ard, sum(n) > 4))
   expect_equal(nrow(ard_f), 144)
@@ -102,7 +102,7 @@ test_that("filter_ard_hierarchical() works with column-specific filters", {
 
   # check for number of rows
   expect_silent(ard_f <- filter_ard_hierarchical(ard, p_overall <= 0.1))
-  expect_equal(nrow(ard_f), 108)
+  expect_equal(nrow(ard_f), 234)
 
   # column-wise n statistic equal to previous derivation with column name specified (both still work)
   expect_message(ard_f <- filter_ard_hierarchical(ard, n_2 > 5))


### PR DESCRIPTION
**New PR for 'only by and id for denominator' with Author**


Fixes #482


--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [X] **All** GitHub Action workflows pass with a :white_check_mark:
- [X] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [X] If a bug was fixed, a unit test was added.
- [X] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [X] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] If a bug was fixed, a unit test was added.
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [x] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".

_Optional Reverse Dependency Checks_:

Install `checked` with `pak::pak("Genentech/checked")` or `pak::pak("checked")`

```shell
# Check dev versions of `cardx`, `gtsummary`, and `tfrmt` which are in the `ddsjoberg` R Universe
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2L, repos = c('https://ddsjoberg.r-universe.dev', 'https://cloud.r-project.org'))"

# Check CRAN reverse dependencies but run tests skipped on CRAN
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"

# Check CRAN reverse dependencies in a CRAN-like environment
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = FALSE), checked.check_build_args = '--as-cran'); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"
```
