### PR TITLE
Use `skip_if_pkg_not_installed()`

### DIFF
--- a/tests/testthat/test-ard_attributes.R
+++ b/tests/testthat/test-ard_attributes.R
@@ -1,4 +1,4 @@
-skip_if_not(is_pkg_installed("withr"))
+skip_if_pkg_not_installed("withr")
 
 test_that("ard_attributes() works", {
   withr::local_options(list(width = 120))

--- a/tests/testthat/test-ard_hierarchical.R
+++ b/tests/testthat/test-ard_hierarchical.R
@@ -348,7 +348,7 @@ test_that("ard_hierarchical_count() errors with incomplete factor columns", {
 })
 
 test_that("ard_hierarchical_count() provides correct results with 10+ groups", {
-  skip_if_not(is_pkg_installed("withr"))
+  skip_if_pkg_not_installed("withr")
   withr::local_seed(1)
 
   expect_silent(

--- a/tests/testthat/test-ard_tabulate.R
+++ b/tests/testthat/test-ard_tabulate.R
@@ -1108,7 +1108,7 @@ test_that("ard_tabulate() follows ard structure", {
 
 test_that("ard_tabulate() with hms times", {
   # originally reported in https://github.com/ddsjoberg/gtsummary/issues/1893
-  skip_if_not_installed("hms")
+  skip_if_pkg_not_installed("hms")
   withr::local_package("hms")
 
   ADSL2 <-

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -1,4 +1,4 @@
-skip_if_not(is_pkg_installed("withr"))
+skip_if_pkg_not_installed("withr")
 
 test_that("options(cards.round_type)", {
   # test that the p is rounded to zero (ie rounded to even) for aliases called by `apply_fmt_fun()`

--- a/tests/testthat/test-shuffle_ard.R
+++ b/tests/testthat/test-shuffle_ard.R
@@ -1,4 +1,4 @@
-skip_if_not(is_pkg_installed("withr"))
+skip_if_pkg_not_installed("withr")
 
 test_that("shuffle/trim works", {
   withr::local_options(list(width = 200))

--- a/tests/testthat/test-tidy_ard_column_order.R
+++ b/tests/testthat/test-tidy_ard_column_order.R
@@ -1,5 +1,5 @@
 test_that("tidy_ard_column_order() works", {
-  skip_if_not(is_pkg_installed("withr"))
+  skip_if_pkg_not_installed("withr")
   withr::local_seed(1)
 
   # ensure 10+ groups are ordered correctly

--- a/tests/testthat/test-tidy_ard_row_order.R
+++ b/tests/testthat/test-tidy_ard_row_order.R
@@ -1,5 +1,5 @@
 test_that("tidy_ard_row_order() works", {
-  skip_if_not(is_pkg_installed("withr"))
+  skip_if_pkg_not_installed("withr")
   withr::local_options(list(width = 120))
   withr::local_seed(1)
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Updated tests to use standalone function `skip_if_pkg_not_installed()`.

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [x] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".

_Optional Reverse Dependency Checks_:

Install `checked` with `pak::pak("Genentech/checked")` or `pak::pak("checked")`

```shell
# Check dev versions of `cardx`, `gtsummary`, and `tfrmt` which are in the `ddsjoberg` R Universe
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2L, repos = c('https://ddsjoberg.r-universe.dev', 'https://cloud.r-project.org'))"

# Check CRAN reverse dependencies but run tests skipped on CRAN
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"

# Check CRAN reverse dependencies in a CRAN-like environment
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = FALSE), checked.check_build_args = '--as-cran'); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"
```
