### PR TITLE
Fix partial matching issue in `sort_ard_hierarchical()`

### DIFF
--- a/.github/workflows/rev-dep-check.yaml
+++ b/.github/workflows/rev-dep-check.yaml
@@ -41,12 +41,14 @@ jobs:
           options(checked.check_envvars = c(NOT_CRAN = TRUE))
           
           tryCatch({
+            # New API from the PR template
             checked::check_rev_deps(
               path = '.', 
               n = parallel::detectCores() - 2L, 
               repos = c('https://ddsjoberg.r-universe.dev', 'https://cloud.r-project.org')
             )
           }, error = function(e) {
+            # Retain the required custom abort message for the maintainers
             cli::cli_abort(
               c('This PR newly breaks reverse dependencies (like {.pkg gtsummary})',
                 '!' = 'The PR must be updated as to not break reverse dependencies.',

--- a/.github/workflows/rev-dep-check.yaml
+++ b/.github/workflows/rev-dep-check.yaml
@@ -37,24 +37,31 @@ jobs:
       - name: Check Reverse Dependencies
         shell: Rscript {0}
         run: |
-          Rscript -e "
-          options(checked.check_envvars = c(NOT_CRAN = TRUE))
-          
-          tryCatch({
-            # New API from the PR template
-            checked::check_rev_deps(
-              path = '.', 
-              n = parallel::detectCores() - 2L, 
-              repos = c('https://ddsjoberg.r-universe.dev', 'https://cloud.r-project.org')
+          df <-
+            checked::rev_dep_check_tasks_df(
+              path = ".",
+              repos = "https://packagemanager.posit.co/cran/latest",
+              versions = c("dev", "release")
             )
-          }, error = function(e) {
-            # Retain the required custom abort message for the maintainers
+          df <- df[startsWith(df$alias, "gtsummary"), ]
+
+          design <-
+            checked::check_design$new(
+              df = df,
+              repos = "https://packagemanager.posit.co/cran/latest",
+              output = tempdir(),
+              restore = FALSE
+            )
+          checked::run(design)
+          checked::results(design)
+
+          # Logic to check for errors and abort if found
+          issues <- checked::results(design)$revdep_check_task_spec$gtsummary$errors$issues
+          if (!rlang::is_empty(issues)) {
             cli::cli_abort(
-              c('This PR newly breaks reverse dependencies (like {.pkg gtsummary})',
-                '!' = 'The PR must be updated as to not break reverse dependencies.',
-                'i' = 'In rare cases where the break is acceptable, the change {.emph MUST} first be approved by Daniel Sjoberg (danieldsjoberg@gmail.com) {.emph before} this PR could potentially be merged.',
-                'x' = e\$message
+              c("This PR newly breaks {.pkg gtsummary}",
+                "!" = "The PR must be updated as to not break {.pkg gtsummary}.",
+                "i" = "In rare cases where the break is acceptable, the change {.emph MUST} first be approved by Daniel Sjoberg (danieldsjoberg@gmail.com) {.emph before} this PR could potentially be merged."
               )
             )
-          })
-          "
+          }

--- a/.github/workflows/rev-dep-check.yaml
+++ b/.github/workflows/rev-dep-check.yaml
@@ -37,31 +37,24 @@ jobs:
       - name: Check Reverse Dependencies
         shell: Rscript {0}
         run: |
-          df <-
-            checked::rev_dep_check_tasks_df(
-              path = ".",
-              repos = "https://packagemanager.posit.co/cran/latest",
-              versions = c("dev", "release")
+          Rscript -e "
+          options(checked.check_envvars = c(NOT_CRAN = TRUE))
+          
+          tryCatch({
+            # New API from the PR template
+            checked::check_rev_deps(
+              path = '.', 
+              n = parallel::detectCores() - 2L, 
+              repos = c('https://ddsjoberg.r-universe.dev', 'https://cloud.r-project.org')
             )
-          df <- df[startsWith(df$alias, "gtsummary"), ]
-
-          design <-
-            checked::check_design$new(
-              df = df,
-              repos = "https://packagemanager.posit.co/cran/latest",
-              output = tempdir(),
-              restore = FALSE
-            )
-          checked::run(design)
-          checked::results(design)
-
-          # Logic to check for errors and abort if found
-          issues <- checked::results(design)$revdep_check_task_spec$gtsummary$errors$issues
-          if (!rlang::is_empty(issues)) {
+          }, error = function(e) {
+            # Retain the required custom abort message for the maintainers
             cli::cli_abort(
-              c("This PR newly breaks {.pkg gtsummary}",
-                "!" = "The PR must be updated as to not break {.pkg gtsummary}.",
-                "i" = "In rare cases where the break is acceptable, the change {.emph MUST} first be approved by Daniel Sjoberg (danieldsjoberg@gmail.com) {.emph before} this PR could potentially be merged."
+              c('This PR newly breaks reverse dependencies (like {.pkg gtsummary})',
+                '!' = 'The PR must be updated as to not break reverse dependencies.',
+                'i' = 'In rare cases where the break is acceptable, the change {.emph MUST} first be approved by Daniel Sjoberg (danieldsjoberg@gmail.com) {.emph before} this PR could potentially be merged.',
+                'x' = e\$message
               )
             )
-          }
+          })
+          "

--- a/.github/workflows/rev-dep-check.yaml
+++ b/.github/workflows/rev-dep-check.yaml
@@ -37,6 +37,7 @@ jobs:
       - name: Check Reverse Dependencies
         shell: Rscript {0}
         run: |
+          Rscript -e "
           options(checked.check_envvars = c(NOT_CRAN = TRUE))
           
           tryCatch({
@@ -50,7 +51,8 @@ jobs:
               c('This PR newly breaks reverse dependencies (like {.pkg gtsummary})',
                 '!' = 'The PR must be updated as to not break reverse dependencies.',
                 'i' = 'In rare cases where the break is acceptable, the change {.emph MUST} first be approved by Daniel Sjoberg (danieldsjoberg@gmail.com) {.emph before} this PR could potentially be merged.',
-                'x' = e$message
+                'x' = e\$message
               )
             )
           })
+          "

--- a/.github/workflows/rev-dep-check.yaml
+++ b/.github/workflows/rev-dep-check.yaml
@@ -37,7 +37,6 @@ jobs:
       - name: Check Reverse Dependencies
         shell: Rscript {0}
         run: |
-          Rscript -e "
           options(checked.check_envvars = c(NOT_CRAN = TRUE))
           
           tryCatch({
@@ -51,8 +50,7 @@ jobs:
               c('This PR newly breaks reverse dependencies (like {.pkg gtsummary})',
                 '!' = 'The PR must be updated as to not break reverse dependencies.',
                 'i' = 'In rare cases where the break is acceptable, the change {.emph MUST} first be approved by Daniel Sjoberg (danieldsjoberg@gmail.com) {.emph before} this PR could potentially be merged.',
-                'x' = e\$message
+                'x' = e$message
               )
             )
           })
-          "

--- a/.github/workflows/rev-dep-check.yaml
+++ b/.github/workflows/rev-dep-check.yaml
@@ -41,14 +41,12 @@ jobs:
           options(checked.check_envvars = c(NOT_CRAN = TRUE))
           
           tryCatch({
-            # New API from the PR template
             checked::check_rev_deps(
               path = '.', 
               n = parallel::detectCores() - 2L, 
               repos = c('https://ddsjoberg.r-universe.dev', 'https://cloud.r-project.org')
             )
           }, error = function(e) {
-            # Retain the required custom abort message for the maintainers
             cli::cli_abort(
               c('This PR newly breaks reverse dependencies (like {.pkg gtsummary})',
                 '!' = 'The PR must be updated as to not break reverse dependencies.',

--- a/R/sort_ard_hierarchical.R
+++ b/R/sort_ard_hierarchical.R
@@ -281,7 +281,7 @@ sort_ard_hierarchical <- function(x, sort = everything() ~ "descending") {
       .data$stat_name == sort_stat, # select statistic to sum
       if (!is_empty(ard_args$by)) .data$group1 %in% ard_args$by else TRUE,
       if (length(c(ard_args$by, ard_args$variables)) > 1) {
-        if (ard_args$variable[i] %in% ard_args$include & !cur_var %in% "variable") {
+        if (ard_args$variables[i] %in% ard_args$include & !cur_var %in% "variable") {
           # if current variable is in include, sum *only* summary rows for the current variable
           .data$variable %in% "..overall.." &
             if (!next_var %in% "variable") .data[[next_var]] %in% "..empty.." else TRUE


### PR DESCRIPTION
There is a typo in line 284 - `variable` instead of `variables` - causing a partial matchin issue downstream. Just a one character typo

**What changes are proposed in this pull request?**
* Style this entry in a way that can be copied directly into `NEWS.md`. (#<issue number>, @<username>)

Provide more detail here as needed.

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_


--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".

_Optional Reverse Dependency Checks_:

Install `checked` with `pak::pak("Genentech/checked")` or `pak::pak("checked")`

```shell
# Check dev versions of `cardx`, `gtsummary`, and `tfrmt` which are in the `ddsjoberg` R Universe
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2L, repos = c('https://ddsjoberg.r-universe.dev', 'https://cloud.r-project.org'))"

# Check CRAN reverse dependencies but run tests skipped on CRAN
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"

# Check CRAN reverse dependencies in a CRAN-like environment
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = FALSE), checked.check_build_args = '--as-cran'); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"
```
