### PR TITLE
Fix NA row names error on R-devel in `.table_as_df()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cards 0.7.1.9011
 
+* Update in `ard_tabulate()` to account for change in `as.data.frame()` being released in R-Devel. (#554)
+
 * Fixed bug in `rename_ard_columns()` whereby factor variables were getting converted to integers and added parameter `fct_as_chr` as is used in `unlist_ard_columns()` (#542)
 
 * Adding `ard_tabulate_rows()` function to tabulate the number of rows in a data frame. (#531)

--- a/R/ard_tabulate.R
+++ b/R/ard_tabulate.R
@@ -434,11 +434,22 @@ ard_tabulate.data.frame <- function(data,
   useNA <- match.arg(useNA)
   # tabulate results and save in data frame
   ...ard_tab_vars... <- c(by, strata, variable)
-  df_table <-
+  ...ard_tab... <-
     data[...ard_tab_vars...] |>
     dplyr::mutate(across(where(is.logical), ~ factor(., levels = c("FALSE", "TRUE")))) |>
-    with(inject(table(!!!syms(...ard_tab_vars...), useNA = !!useNA))) |>
-    dplyr::as_tibble(n = count_column)
+    with(inject(table(!!!syms(...ard_tab_vars...), useNA = !!useNA)))
+
+  # replace NA dimnames with placeholder to avoid R-devel error in as.data.frame()
+  ...ard_na_placeholder... <- "___cards_table_NA_PLACEHOLDER___"
+  dimnames(...ard_tab...) <- lapply(dimnames(...ard_tab...), function(x) {
+    x[is.na(x)] <- ...ard_na_placeholder...
+    x
+  })
+
+  df_table <-
+    ...ard_tab... |>
+    dplyr::as_tibble(n = count_column) |>
+    dplyr::mutate(across(all_of(...ard_tab_vars...), ~ dplyr::na_if(., ...ard_na_placeholder...)))
 
   # construct a matching data frame with the variables in their original type/class
   df_original_types <-


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Fixed R-devel compatibility issue where `as.data.frame()` now errors on NA row names, breaking `.table_as_df()` when `table(useNA = "always")` produces NA dimnames. (#553)

R-devel ([R PR#19059](https://bugs.r-project.org/show_bug.cgi?id=19059)) changed `as.data.frame.vector()` to reject NA row names. This caused `.table_as_df()` to fail because `table(..., useNA = "always")` produces NA entries in dimnames, and the downstream `dplyr::as_tibble()` → `as.data.frame()` conversion now errors.

The fix replaces NA dimnames with a placeholder string before the `as_tibble()` call, then restores them to NA with `dplyr::na_if()` afterward. This is a minimal, targeted change confined to lines 437–451 of `R/ard_tabulate.R`.

**Reference GitHub issue associated with pull request.** closes #553

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading \"`# cards (development version)`\". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use \"Squash and merge\" or \"Rebase and merge\".