### PR TITLE
deprecation cycle updates

### DIFF
--- a/R/add_calculated_row.R
+++ b/R/add_calculated_row.R
@@ -48,7 +48,7 @@ add_calculated_row <- function(x,
 
   # deprecated args ------------------------------------------------------------
   if (lifecycle::is_present(fmt_fn)) {
-    lifecycle::deprecate_soft(
+    lifecycle::deprecate_warn(
       when = "0.6.1",
       what = "add_calculated_row(fmt_fn)",
       with = "add_calculated_row(fmt_fun)"

--- a/R/ard_hierarchical.R
+++ b/R/ard_hierarchical.R
@@ -85,7 +85,7 @@ ard_hierarchical.data.frame <- function(data,
 
   # deprecated args ------------------------------------------------------------
   if (lifecycle::is_present(fmt_fn)) {
-    lifecycle::deprecate_soft(
+    lifecycle::deprecate_warn(
       when = "0.6.1",
       what = "ard_hierarchical(fmt_fn)",
       with = "ard_hierarchical(fmt_fun)"
@@ -184,7 +184,7 @@ ard_hierarchical_count.data.frame <- function(data,
 
   # deprecated args ------------------------------------------------------------
   if (lifecycle::is_present(fmt_fn)) {
-    lifecycle::deprecate_soft(
+    lifecycle::deprecate_warn(
       when = "0.6.1",
       what = "ard_hierarchical_count(fmt_fn)",
       with = "ard_hierarchical_count(fmt_fun)"

--- a/R/ard_missing.R
+++ b/R/ard_missing.R
@@ -42,7 +42,7 @@ ard_missing.data.frame <- function(data,
 
   # deprecated args ------------------------------------------------------------
   if (lifecycle::is_present(fmt_fn)) {
-    lifecycle::deprecate_soft(
+    lifecycle::deprecate_warn(
       when = "0.6.1",
       what = "ard_missing(fmt_fn)",
       with = "ard_missing(fmt_fun)"

--- a/R/ard_mvsummary.R
+++ b/R/ard_mvsummary.R
@@ -73,7 +73,7 @@ ard_mvsummary.data.frame <- function(data,
 
   # deprecated args ------------------------------------------------------------
   if (lifecycle::is_present(fmt_fn)) {
-    lifecycle::deprecate_soft(
+    lifecycle::deprecate_warn(
       when = "0.6.1",
       what = "ard_summary(fmt_fn)",
       with = "ard_summary(fmt_fun)"

--- a/R/ard_stack.R
+++ b/R/ard_stack.R
@@ -162,7 +162,7 @@ ard_stack <- function(data,
 
   # shuffle --------------------------------------------------------------------
   if (isTRUE(.shuffle)) {
-    lifecycle::deprecate_warn(
+    lifecycle::deprecate_stop(
       when = "0.7.0",
       what = "cards::ard_stack(.shuffle)"
     )

--- a/R/ard_stack.R
+++ b/R/ard_stack.R
@@ -162,7 +162,7 @@ ard_stack <- function(data,
 
   # shuffle --------------------------------------------------------------------
   if (isTRUE(.shuffle)) {
-    lifecycle::deprecate_stop(
+    lifecycle::deprecate_warn(
       when = "0.7.0",
       what = "cards::ard_stack(.shuffle)"
     )

--- a/R/ard_summary.R
+++ b/R/ard_summary.R
@@ -84,7 +84,7 @@ ard_summary.data.frame <- function(data,
 
   # deprecated args ------------------------------------------------------------
   if (lifecycle::is_present(fmt_fn)) {
-    lifecycle::deprecate_soft(
+    lifecycle::deprecate_warn(
       when = "0.6.1",
       what = "ard_summary(fmt_fn)",
       with = "ard_summary(fmt_fun)"

--- a/R/ard_tabulate.R
+++ b/R/ard_tabulate.R
@@ -105,7 +105,7 @@ ard_tabulate.data.frame <- function(data,
 
   # deprecated args ------------------------------------------------------------
   if (lifecycle::is_present(fmt_fn)) {
-    lifecycle::deprecate_soft(
+    lifecycle::deprecate_warn(
       when = "0.6.1",
       what = "ard_tabulate(fmt_fn)",
       with = "ard_tabulate(fmt_fun)"

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -21,15 +21,15 @@ NULL
 
 # "soft" deprecation for 6 months: (Sys.Date() - lubridate::dmonths(6)) |> as.Date()
 #  v0.7.1 2025-12-02
+
+# "warn" deprecation for 12 months: (Sys.Date() - lubridate::dmonths(12)) |> as.Date()
 #  v0.7.0 2025-08-27
 #  v0.6.1 2025-07-03
 #  v0.6.0 2025-04-11
 #  v0.5.1 2025-03-01
 
-# "warn" deprecation for 12 months: (Sys.Date() - lubridate::dmonths(12)) |> as.Date()
-#  v0.5.0 2025-02-17
-
 # "stop" deprecation for 18 months: (Sys.Date() - lubridate::dmonths(18)) |> as.Date()
+#  v0.5.0 2025-02-17
 
 # v0.7.0 -----------------------------------------------------------------------
 # These were dropped from the documentation in v0.7.0. But were not officially deprecated
@@ -101,7 +101,7 @@ ard_dichotomous.data.frame <- function(data, ...) {
 #' @rdname deprecated
 #' @export
 apply_fmt_fn <- function(...) {
-  lifecycle::deprecate_soft(
+  lifecycle::deprecate_warn(
     when = "0.6.1",
     what = "cards::apply_fmt_fn()",
     with = "apply_fmt_fun()"
@@ -113,7 +113,7 @@ apply_fmt_fn <- function(...) {
 #' @rdname deprecated
 #' @export
 alias_as_fmt_fn <- function(...) {
-  lifecycle::deprecate_soft(
+  lifecycle::deprecate_warn(
     when = "0.6.1",
     what = "cards::alias_as_fmt_fn()",
     with = "alias_as_fmt_fun()"
@@ -125,7 +125,7 @@ alias_as_fmt_fn <- function(...) {
 #' @rdname deprecated
 #' @export
 update_ard_fmt_fn <- function(...) {
-  lifecycle::deprecate_soft(
+  lifecycle::deprecate_warn(
     when = "0.6.1",
     what = "cards::update_ard_fmt_fn()",
     with = "update_ard_fmt_fun()"


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Style this entry in a way that can be copied directly into `NEWS.md`. (#<issue number>, @<username>)

Provide more detail here as needed.

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_


--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`
- [ ] Request a reviewer

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cards (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".

_Optional Reverse Dependency Checks_:

Install `checked` with `pak::pak("Genentech/checked")` or `pak::pak("checked")`

```shell
# Check dev versions of `cardx`, `gtsummary`, and `tfrmt` which are in the `ddsjoberg` R Universe
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2L, repos = c('https://ddsjoberg.r-universe.dev', 'https://cloud.r-project.org'))"

# Check CRAN reverse dependencies but run tests skipped on CRAN
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = TRUE)); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"

# Check CRAN reverse dependencies in a CRAN-like environment
Rscript -e "options(checked.check_envvars = c(NOT_CRAN = FALSE), checked.check_build_args = '--as-cran'); checked::check_rev_deps(path = '.', n = parallel::detectCores() - 2, repos = 'https://cloud.r-project.org')"
```
